### PR TITLE
added warning on beginner tutorials about utils.mkdir if reset=True

### DIFF
--- a/notebooks/deal_with_errors.ipynb
+++ b/notebooks/deal_with_errors.ipynb
@@ -56,6 +56,10 @@
     "\n",
     "# Local working directory (where OGGM will write its output)\n",
     "WORKING_DIR = utils.gettempdir('OGGM_Errors')\n",
+    "# Attention: if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)`\n",
+    "# when you define the `working_dir`, all files of that folder (also those not created by OGGM)\n",
+    "# are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory\n",
+    "# or if you are sure that the entire content of that folder can be removed!\n",
     "utils.mkdir(WORKING_DIR, reset=True)\n",
     "cfg.PATHS['working_dir'] = WORKING_DIR\n",
     "\n",
@@ -292,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -153,7 +153,7 @@
     "**This working directory is meant to be persistent**, i.e. you can stop your processing workflow after any task, and restart from an existing working directory at a later stage.\n",
     "\n",
     "\n",
-    "<span style=\"color:red\">**Attention:**</span> if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)` when you define the `working_dir`, all files of that folder (also those not created by OGGM) are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory or if you are sure that the entire content of that folder can be removed!"
+    "**Attention:** if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)` when you define the `working_dir`, all files of that folder (also those not created by OGGM) are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory or if you are sure that the entire content of that folder can be removed!"
    ]
   },
   {

--- a/notebooks/getting_started.ipynb
+++ b/notebooks/getting_started.ipynb
@@ -150,7 +150,10 @@
    "source": [
     "We use a temporary directory for this example, but in practice you will set this working directory yourself (for example: `/home/john/OGGM_output`. The size of this directory will depend on how many glaciers you'll simulate!\n",
     "\n",
-    "**This working directory is meant to be persistent**, i.e. you can stop your processing workflow after any task, and restart from an existing working directory at a later stage."
+    "**This working directory is meant to be persistent**, i.e. you can stop your processing workflow after any task, and restart from an existing working directory at a later stage.\n",
+    "\n",
+    "\n",
+    "<span style=\"color:red\">**Attention:**</span> if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)` when you define the `working_dir`, all files of that folder (also those not created by OGGM) are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory or if you are sure that the entire content of that folder can be removed!"
    ]
   },
   {
@@ -928,7 +931,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/notebooks/hydrological_output.ipynb
+++ b/notebooks/hydrological_output.ipynb
@@ -1096,7 +1096,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/inversion.ipynb
+++ b/notebooks/inversion.ipynb
@@ -61,6 +61,10 @@
     "\n",
     "# Local working directory (where OGGM will write its output)\n",
     "WORKING_DIR = utils.gettempdir('OGGM_Inversion')\n",
+    "# Attention: if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)`\n",
+    "# when you define the `working_dir`, all files of that folder (also those not created by OGGM)\n",
+    "# are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory\n",
+    "# or if you are sure that the entire content of that folder can be removed!\n",
     "utils.mkdir(WORKING_DIR, reset=True)\n",
     "cfg.PATHS['working_dir'] = WORKING_DIR\n",
     "\n",
@@ -609,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "metadata": {
    "interpreter": {

--- a/notebooks/kcalving_parameterization.ipynb
+++ b/notebooks/kcalving_parameterization.ipynb
@@ -654,7 +654,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/store_and_compress_glacierdirs.ipynb
+++ b/notebooks/store_and_compress_glacierdirs.ipynb
@@ -64,6 +64,10 @@
     "\n",
     "# Local working directory (where OGGM will write its output)\n",
     "WORKING_DIR = utils.gettempdir('oggm_gdirs_wd')\n",
+    "# Attention: if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)`\n",
+    "# when you define the `working_dir`, all files of that folder (also those not created by OGGM)\n",
+    "# are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory\n",
+    "# or if you are sure that the entire content of that folder can be removed!\n",
     "utils.mkdir(WORKING_DIR, reset=True)\n",
     "cfg.PATHS['working_dir'] = WORKING_DIR\n",
     "\n",
@@ -425,7 +429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/notebooks/welcome.ipynb
+++ b/notebooks/welcome.ipynb
@@ -67,7 +67,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -81,7 +81,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.4"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
In the tutorials, the working_dir is often created via `utils.mkdir(...., reset=True)`. When people use this on folders with other data, the content of the folder can get removed. To at least warn the users, I added the following to the beginner tutorials (once in the text in `getting_started.ipynb` when the working_dir gets introduced and as code comment on the other notebooks):

> Attention: if you use `reset=True` together with `utils.mkdir(path_to_folder, reset=True)` when you define the `working_dir`, all files of that folder (also those not created by OGGM) are removed or overwritten. So, only use `reset=True` if you have e.g. a temporary directory or if you are sure that the entire content of that folder can be removed!

Thanks to Kim Cholibois for reporting this issue! 