### PR TITLE
Using rioxarray.open_rasterio() instead of xarray.open_rasterio() in the tutorial notebooks

### DIFF
--- a/notebooks/dem_comparison.ipynb
+++ b/notebooks/dem_comparison.ipynb
@@ -133,6 +133,7 @@
     "import numpy as np\n",
     "from oggm import cfg, utils, workflow, tasks, graphics, GlacierDirectory\n",
     "import xarray as xr\n",
+    "import rioxarray as rioxr\n",
     "import geopandas as gpd\n",
     "import salem\n",
     "import matplotlib.pyplot as plt\n",
@@ -258,14 +259,14 @@
     "ods = xr.Dataset()\n",
     "for src in sources:\n",
     "    demfile = os.path.join(gdir.dir, src) + '/dem.tif'\n",
-    "    with xr.open_rasterio(demfile) as ds:\n",
+    "    with rioxr.open_rasterio(demfile) as ds:\n",
     "        data = ds.sel(band=1).load() * 1.\n",
     "        ods[src] = data.where(data > -100, np.NaN)\n",
     "    \n",
     "    sy, sx = np.gradient(ods[src], gdir.grid.dx, gdir.grid.dx)\n",
     "    ods[src + '_slope'] = ('y', 'x'),  np.arctan(np.sqrt(sy**2 + sx**2))\n",
     "\n",
-    "with xr.open_rasterio(gdir.get_filepath('glacier_mask')) as ds:\n",
+    "with rioxr.open_rasterio(gdir.get_filepath('glacier_mask')) as ds:\n",
     "    ods['mask'] = ds.sel(band=1).load()"
    ]
   },
@@ -683,7 +684,7 @@
   "celltoolbar": "Tags",
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -697,7 +698,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.10"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/notebooks/dem_sources.ipynb
+++ b/notebooks/dem_sources.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
+    "import rioxarray as rioxr\n",
     "import matplotlib.pyplot as plt\n",
     "import oggm\n",
     "from oggm import cfg, utils, workflow, tasks, graphics\n",
@@ -119,7 +119,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "da = xr.open_rasterio(dem_path)\n",
+    "da = rioxr.open_rasterio(dem_path)\n",
     "f, ax = plt.subplots()\n",
     "da.plot(cmap='terrain', ax=ax);\n",
     "# Add the outlines\n",
@@ -264,7 +264,7 @@
    "outputs": [],
    "source": [
     "f, ax = plt.subplots()\n",
-    "da_dem3 = xr.open_rasterio(gdir.get_filepath('dem'))\n",
+    "da_dem3 = rioxr.open_rasterio(gdir.get_filepath('dem'))\n",
     "da_dem3.plot(cmap='terrain', ax=ax);\n",
     "gdir.read_shapefile('outlines').plot(ax=ax, color='none', edgecolor='black');"
    ]
@@ -382,7 +382,7 @@
    "outputs": [],
    "source": [
     "f, ax = plt.subplots()\n",
-    "da_user = xr.open_rasterio(gdir.get_filepath('dem'))\n",
+    "da_user = rioxr.open_rasterio(gdir.get_filepath('dem'))\n",
     "da_user.plot(cmap='terrain', ax=ax);\n",
     "gdir.read_shapefile('outlines').plot(ax=ax, color='none', edgecolor='black');"
    ]
@@ -432,7 +432,7 @@
     "cfg.PATHS['working_dir'] = utils.gettempdir('border1')\n",
     "gdir = workflow.init_glacier_directories(entity)[0]\n",
     "tasks.define_glacier_region(gdir)\n",
-    "da = xr.open_rasterio(gdir.get_filepath('dem'))\n",
+    "da = rioxr.open_rasterio(gdir.get_filepath('dem'))\n",
     "f, ax = plt.subplots()\n",
     "da.plot(cmap='terrain', ax=ax);\n",
     "# Add the outlines\n",
@@ -458,7 +458,7 @@
     "cfg.PATHS['working_dir'] = utils.gettempdir('border100')\n",
     "gdir = workflow.init_glacier_directories(entity)[0]\n",
     "tasks.define_glacier_region(gdir)\n",
-    "da = xr.open_rasterio(gdir.get_filepath('dem'))\n",
+    "da = rioxr.open_rasterio(gdir.get_filepath('dem'))\n",
     "f, ax = plt.subplots()\n",
     "da.plot(cmap='terrain', ax=ax);\n",
     "# Add the outlines\n",
@@ -479,7 +479,7 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -493,7 +493,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.10"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,

--- a/notebooks/inversion.ipynb
+++ b/notebooks/inversion.ipynb
@@ -400,6 +400,7 @@
    "source": [
     "# xarray is an awesome library! Did you know about it?\n",
     "import xarray as xr\n",
+    "import rioxarray as rioxr\n",
     "ds = xr.open_dataset(gdirs[0].get_filepath('gridded_data'))"
    ]
   },
@@ -442,7 +443,7 @@
    "outputs": [],
    "source": [
     "# Open the last file with xarray's open_rasterio\n",
-    "xr.open_rasterio(path).plot();"
+    "rioxr.open_rasterio(path).plot();"
    ]
   },
   {
@@ -579,16 +580,6 @@
     "f, ax = plt.subplots(figsize=(6, 6))\n",
     "smap.visualize(ax=ax, cbar_title='Glacier thickness (m)');"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## What's next?\n",
-    "\n",
-    "- return to the [OGGM documentation](https://docs.oggm.org)\n",
-    "- back to the [table of contents](welcome.ipynb)"
-   ]
   }
  ],
  "metadata": {
@@ -608,7 +599,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.10"
   },
   "metadata": {
    "interpreter": {

--- a/notebooks/oggm_shop.ipynb
+++ b/notebooks/oggm_shop.ipynb
@@ -333,20 +333,21 @@
    "outputs": [],
    "source": [
     "# We use xarray to store the data\n",
+    "import rioxarray as rioxr\n",
     "import xarray as xr\n",
     "import numpy as np\n",
     "\n",
     "ods = xr.Dataset()\n",
     "for src in sources:\n",
     "    demfile = os.path.join(gdir.dir, src) + '/dem.tif'\n",
-    "    with xr.open_rasterio(demfile) as ds:\n",
+    "    with rioxr.open_rasterio(demfile) as ds:\n",
     "        data = ds.sel(band=1).load() * 1.\n",
     "        ods[src] = data.where(data > -100, np.NaN)\n",
     "\n",
     "    sy, sx = np.gradient(ods[src], gdir.grid.dx, gdir.grid.dx)\n",
     "    ods[src + '_slope'] = ('y', 'x'),  np.arctan(np.sqrt(sy**2 + sx**2))\n",
     "\n",
-    "with xr.open_rasterio(gdir.get_filepath('glacier_mask')) as ds:\n",
+    "with rioxr.open_rasterio(gdir.get_filepath('glacier_mask')) as ds:\n",
     "    ods['mask'] = ds.sel(band=1).load()"
    ]
   },
@@ -650,13 +651,20 @@
     "- return to the [OGGM documentation](https://docs.oggm.org)\n",
     "- back to the [table of contents](welcome.ipynb)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -670,7 +678,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.9.10"
   },
   "latex_envs": {
    "LaTeX_envs_menu_present": true,


### PR DESCRIPTION
As the usage of the function `xr.open_rasterio()` has resulted in a deprication warning, the `rioxarray` library is now used for this function call instead. This has been changed for all usages of this method in any tutorial notebook. 