### PR TITLE
added notebook explaining OGGM_v16 calibration

### DIFF
--- a/notebooks/massbalance_calibration_oggm_v16.ipynb
+++ b/notebooks/massbalance_calibration_oggm_v16.ipynb
@@ -1,0 +1,923 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# A quick look into the mass-balance calibration procedure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default mass-balance (MB) model of OGGM is a very standard [temperature index melt model](https://www.sciencedirect.com/science/article/pii/S0022169403002579). At the beginning, OGGM had a very complicated calibration procedure where the glaciers with in-situ data were calibrated and then a so-called *tstar* got interpolated for glaciers without observations (see the [original publication](https://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html)). This method was very powerful, however, as new observational datasets emerged, we can finally calibrate on a glacier-per-glacier basis. With the new era of geodetic observations, OGGM uses per default the average geodetic observations from Jan 2000--Jan 2020 of [Hugonnet al. 2021](https://www.nature.com/articles/s41586-021-03436-z), that are now available for every glacier world-wide. \n",
+    "\n",
+    "In this tutorial, we will:\n",
+    "- introduce the default calibration procedure \n",
+    "- show how we can calibrate on other data (e.g. from direct glaciological observations from a glacier with in-situ observations) \n",
+    "- show the influence of different calibration options and explain the overparameterisation problem (more explanations in [Schuster et al., 2023]())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "TODO: \n",
+    "- add links to Schuster et al., 2023 preprint\n",
+    "- add other example glacier(s) where in situ-mb != geodetic MB\n",
+    "- add something about the regional dependence of the temperature bias and the way it is used in the OGGM preprocessed levels>=3 \n",
+    "- maybe make the structure a bit easier to read? "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Set-up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import os\n",
+    "\n",
+    "import oggm\n",
+    "from oggm import cfg, utils, workflow, tasks, graphics\n",
+    "from oggm.core import massbalance, climate\n",
+    "from oggm.core.massbalance import mb_calibration_from_geodetic_mb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.initialize(logging_level='WARNING')\n",
+    "cfg.PARAMS['monthly_melt_f_max'] = 500 ## to do: remove this when this is changed per default\n",
+    "cfg.PATHS['working_dir'] = utils.gettempdir(dirname='OGGM-calib-mb', reset=True)\n",
+    "cfg.PARAMS['border'] = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start from two well known glaciers in the Austrian Alps, Kesselwandferner and Hintereisferner:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# todo: select another glacier maybe in Pakistan without any MB observations\n",
+    "# we start from preprocessing level 2\n",
+    "# in OGGM v1.6 you have to explicitly indacate the url from where you want to start from\n",
+    "# we will use here the elevation band flowlines which are much simpler than the centerlines\n",
+    "base_url = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'\n",
+    "            'L1-L2_files/elev_bands')\n",
+    "gdirs = workflow.init_glacier_directories(['RGI60-11.00787', 'RGI60-11.00897'], from_prepro_level=2,\n",
+    "                                         prepro_base_url=base_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start from prepro_level 2, so we also need to process the climate ourselves:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.PARAMS['baseline_climate']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# creates a climate file with the baseline climate, if you want to change the climate, you have to do that here, before the calibration!\n",
+    "workflow.execute_entity_task(tasks.process_climate_data, gdirs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The two glaciers are neighbors but have very different geometries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots(figsize=(8, 8))\n",
+    "graphics.plot_googlemap(gdirs, ax=ax)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Default calibration (OGGM >=v1.6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Let's apply the default mass-balance calibration:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.PARAMS['geodetic_mb_period']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Per default the [Hugonnet et al. (2021)](https://www.nature.com/articles/s41586-021-03436-z) average geodetic observation is used over the entire time period Jan 2000 to Jan 2020 to calibrate the melt factor (`melt_f`) for every single glacier: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow.execute_entity_task(mb_calibration_from_geodetic_mb, gdirs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output shows you the calibrated MB model parameters. Between the two glaciers, only the `melt_f` changed. In the default option, the precipitation factor (`prcp_fac`), depends on the average winter precipitation which is the same for the two neighbouring glaciers (they get their climate from the same climate gridpoint). \n",
+    "\n",
+    "The following figure shows the used relationship between winter precipitation and precipitation factor. It was calibrated by matching both, `melt_f` and `prcp_fac`, to match the average geodetic and winter MB on around 100 glaciers with both informations available. The found relationship of decreasing `prcp_fac` for increasing winter precipitation makes sense, as glaciers with already a large winter precipitation should not be corrected with a large multiplicative `prcp_fac`.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oggm.utils import clip_array\n",
+    "w_prcp_array = np.arange(0.5,20,1)\n",
+    "a, b = cfg.PARAMS['winter_prcp_factor_ab']\n",
+    "r0, r1 = cfg.PARAMS['winter_prcp_factor_range']\n",
+    "\n",
+    "prcp_fac = a * np.log(w_prcp_array) + b\n",
+    "# don't allow extremely low/high prcp. factors!!!\n",
+    "prcp_fac_array = clip_array(prcp_fac, r0, r1)\n",
+    "plt.plot(w_prcp_array, prcp_fac_array)\n",
+    "plt.xlabel('winter daily mean precipitation (kg m-2 day-1)')\n",
+    "plt.ylabel('precipitation factor (prcp_fac)');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the default calibration option, we don't apply a temperature bias (`temp_bias`), which could potentially correct the climate to the local scale. However, we will change the three MB model parameters (`melt_f`, `temp_bias` and `prcp_fac`) later and see their influence on the calibration. \n",
+    "\n",
+    "There are also some global MB parameters (`mb_global_params`), which we assume to be the same globally. These parameters were found to represent best the in-situ observations during a cross-validation using glaciers with additional observations. Of course, they could also be different for different glaciers, but this is another story!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the two glaciers are in the same climate (from the forcing data) but are very different in size, orientation and geometry. So, the resulting `melt_f` and also the MB values are also different:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for gdir in gdirs:\n",
+    "    mbmod = massbalance.MonthlyTIModel(gdir)\n",
+    "    mean_mb = mbmod.get_specific_mb(fls=gdir.read_pickle('inversion_flowlines'),\n",
+    "                                               year=np.arange(2000,2020,1)).mean()\n",
+    "    print(gdir.rgi_id, f': average MB 2000-2020 = {mean_mb:.1f} kg m-2, ',\n",
+    "          f\"melt_f: {gdir.read_json('mb_calib')['melt_f']:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Kesselwandferner has a less negative MB than its neighbor, probably because it is smaller in size and spans less altitude."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*To simplify things, we will now focus just on one glacier:*\n",
+    "\n",
+    "Let's check if the calibration worked: \n",
+    "- We will get first the average modelled MB"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdir = gdirs[-1]\n",
+    "h, w = gdir.get_inversion_flowline_hw()\n",
+    "mb_geod = massbalance.MonthlyTIModel(gdir)\n",
+    "# Note, if you change cfg.PARAMS['geodetic_mb_period'], you need to change the years here as well!\n",
+    "mbdf= pd.DataFrame(index = np.arange(2000,2020,1))\n",
+    "mbdf['mod_mb'] = mb_geod.get_specific_mb(h, w, year=mbdf.index)\n",
+    "mbdf.mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- then get the observed geodetic MB that we calibrated our mass-balance to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_geod_mb = utils.get_geodetic_mb_dataframe().loc[gdir.rgi_id]\n",
+    "ref_geod_mb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "   - We calibrated on the entire 20-yr time period, because then the observational uncertainties are smallest (in the table called: `err_dmdtda`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_geod_mb_period = ref_geod_mb.loc[ref_geod_mb.period==cfg.PARAMS['geodetic_mb_period']].dmdtda*1000\n",
+    "ref_geod_mb_period"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this tests if the two parameters are very similar:\n",
+    "np.testing.assert_allclose(ref_geod_mb_period, mbdf['mod_mb'].mean())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Perfect! Our MB model reproduces the average observed MB, so the calibrated worked!\n",
+    "\n",
+    "We have calibrated the `melt_f` to match the average geodetic observation and fixed the other parameters. We will now instead fix the `melt_f` and the `prcp_fac` and use the `temp_bias` as free variable for calibration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's calibrate on the temp_bias instead\n",
+    "# overwrite_gdir has to be set to True, because we want to overwrite the old calibration\n",
+    "mb_calibration_from_geodetic_mb(gdir,\n",
+    "                                calibrate_param1='temp_bias',\n",
+    "                                overwrite_gdir=True)\n",
+    "\n",
+    "mb_temp_b = massbalance.MonthlyTIModel(gdir)\n",
+    "mbdf['mod_mb_temp_b'] = mb_temp_b.get_specific_mb(h, w, year=mbdf.index)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's read the new calibrated MB model parameter for the glacier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "gdir.read_json('mb_calib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we used the median melt_f (i.e. 180 kg m-2 month-1 K-1) and changed the temperature bias until the average reference MB is matched. As the `melt_f` is lower than in the previous calibration option, we need to have a positive `temp_bias` to get to the same average MB."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**We can do the same with the precipitation factor (`prcp_fac`):** "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's calibrate on the prcp_fac instead\n",
+    "# overwrite_gdir has to be set to True, because we want to overwrite the old calibration\n",
+    "mb_calibration_from_geodetic_mb(gdir,\n",
+    "                                calibrate_param1='prcp_fac',\n",
+    "                                overwrite_gdir=True)\n",
+    "\n",
+    "mb_prcp_fac = massbalance.MonthlyTIModel(gdir)\n",
+    "mbdf['mod_mb_prcp_fac'] = mb_prcp_fac.get_specific_mb(h, w, year=mbdf.index)\n",
+    "gdir.read_json('mb_calib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We chose two glaciers that actually have also in-situ observations available. \n",
+    "We will get the in-situ observations like that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mbdf['in_situ_mb'] = gdir.get_ref_mb_data().loc[2000:2019]['ANNUAL_BALANCE']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's plot how well we match the interannual observations for the different options:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(mbdf['in_situ_mb'], label='in-situ observations\\n'+f'average 2000-2020: {mbdf.in_situ_mb.mean():.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
+    "plt.plot(mbdf['mod_mb'],\n",
+    "         label='modelled mass-balance via calibrating melt_f\\n'+f'average 2000-2020: {mbdf.mod_mb.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "plt.plot(mbdf['mod_mb_temp_b'],\n",
+    "         label='modelled mass-balance via calibrating temp_bias\\n'+f'average 2000-2020: {mbdf.mod_mb_temp_b.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "plt.plot(mbdf['mod_mb_prcp_fac'],\n",
+    "         label='modelled mass-balance via calibrating prcp_fac\\n'+f'average 2000-2020: {mbdf.mod_mb_prcp_fac.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "plt.xticks(np.arange(2000,2020,2))\n",
+    "plt.legend(bbox_to_anchor=(1,1))\n",
+    "plt.ylabel(r'specific mass-balance (kg m$^{-2}$)')\n",
+    "plt.xlabel('Year');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this glacier, over the same time period (here 2000-2020), the average MB is quite similar between the geodetic and in-situ observation and could even be explained by the fact that the in-situ observations are in hydrological years (starting in October of the previous year) and the geodetic observations are in calendar years. If you repeat the analysis for another glacier (e.g. TODO), you will see larger discrepancies. You can also see, that the annual MB is different between the years and we will analyse this more systematically later! "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Other calibration options for glaciers with additional observations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ok, but actually you might trust the in-situ observations much more than the geodetic observation. So if you are only interested in glaciers with these in-situ observations, you can also use the in-situ observations for calibration. We will also calibrate instead over the entire time period.  \n",
+    "\n",
+    "Attention: For the Hintereisferner glacier with a 70-year long time series, the assumption that we make, i.e., that the area does not change over the time period, gets more problematic. So think twice before repeating this at home!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mbdf_in_situ = gdir.get_ref_mb_data()\n",
+    "mbdf_in_situ['ref_mb'] = mbdf_in_situ['ANNUAL_BALANCE']\n",
+    "ref_mb = mbdf_in_situ.ref_mb.mean()\n",
+    "ref_period = f'{mbdf_in_situ.index[0]}-01-01_{mbdf_in_situ.index[-1] + 1}-01-01'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"We will calibrate now the `melt_f` to match the observed average {ref_mb:.1f} kg m-2 over the time period {ref_period}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb, ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True)\n",
+    "mb_in_situ_obs = massbalance.MonthlyTIModel(gdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mbdf_in_situ['mod_mb'] = mb_in_situ_obs.get_specific_mb(h, w, year=mbdf_in_situ.index)\n",
+    "plt.plot(mbdf_in_situ['ref_mb'], label='in-situ observations\\n'+f'average: {ref_mb:.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
+    "plt.plot(mbdf_in_situ['mod_mb'],\n",
+    "         label='modelled mass-balance\\nvia calibrating melt_f\\n'+f'average: {mbdf_in_situ.mod_mb.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.ylabel(r'specific mass-balance (kg m$^{-2}$)')\n",
+    "plt.xlabel('Year');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we look, however, into the annual mass-balance time series we do see quite some discrepancies:\n",
+    "Although the average MB over the 70-year time period is mached, the interannual mass-balance variability is not matched. And also the correlation between modelled and observed annual MB is not perfect:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mbdf_in_situ.corr()['ref_mb']['mod_mb']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Include your own mass-balance observations and dealing with errors\n",
+    "\n",
+    "In the same way, you can also use your own mass-balance observations to calibrate the mass-balance model. We use here as an example, an unrealistically hight positive MB over a 10-year time period:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_period = '2000-01-01_2010-01-01'\n",
+    "ref_mb = 2000 # Let's use an unrealistically positive  mass-balance\n",
+    "mb_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb,\n",
+    "                                ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We got a `RuntimeError` that says that the `ref_mb` is not matched and that we should set `calibrate_param2`. What happened? \n",
+    "Well, no `melt_f` parameter could be found in the given ranges that could create such\n",
+    "a positive `ref_mb`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What are the current minimum and maximum ranges of the melt factor (unit: kg m-2 month-1 K-1)\n",
+    "cfg.PARAMS['monthly_melt_f_min'], cfg.PARAMS['monthly_melt_f_max']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we believe that our observations are true, maybe the climate or the processes represented by the MB model are erroneous. \n",
+    "\n",
+    "What can we do to still match the `ref_mb`? We can either change the `melt_f` ranges by setting other values to the parameters above or we can allow that another parameter is changed (i.e., `calibrate_param2`). This is basically very similar to the three-step-calibration \n",
+    "first introduced in [Huss & Hock 2015](https://doi.org/10.3389/feart.2015.00054), but you can choose your parameter ranges and parameter order yourself. \n",
+    "\n",
+    "For our example, we will first change the `melt_f` and then change the `temp_bias` (this is the option that is used operationally in OGGM in the preprocessed levels >=3 for all glaciers world-wide):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Allowing another parameter to change is done by defining calibrate_param2\n",
+    "mb_calibration_from_geodetic_mb(gdir,ref_mb=ref_mb,\n",
+    "                                ref_period=ref_period,\n",
+    "                                calibrate_param2='temp_bias',\n",
+    "                               overwrite_gdir=True)\n",
+    "\n",
+    "mb_new = massbalance.MonthlyTIModel(gdir)\n",
+    "# ok, we actually matched the new ref_mb\n",
+    "np.testing.assert_allclose(ref_mb,\n",
+    "                           mb_new.get_specific_mb(h, w, year=np.arange(2000,2010,1)).mean())\n",
+    "# Let's look at the calibrated parameters\n",
+    "gdir.read_json('mb_calib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ok, in that case, the climate was too warm to allow for such a positive MB. Even the lowest possible `melt_f` did not create positive enough MB. So, as a next step the temperature was corrected by using a negative `temp_bias`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also the `temp_bias` has a limited range:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.PARAMS['temp_bias_min'], cfg.PARAMS['temp_bias_max']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So, if we increase the `ref_mb` even further, we might even need a third free parameter (i.e., `calibrate_param3`). \n",
+    "Let's try it out:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_mb = 3500\n",
+    "mb_calibration_from_geodetic_mb(gdir,ref_mb=ref_mb,\n",
+    "                                ref_period=ref_period,\n",
+    "                                calibrate_param2='temp_bias',\n",
+    "                                calibrate_param3='prcp_fac',\n",
+    "                               overwrite_gdir=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In that case, the minimum `melt_f` and the minimum `temp_bias` are applied. The `prcp_fac` is increased as this results in more solid precipitation. If you increased the `ref_mb` even further, the method will not find any combination as the `prcp_fac` also has a limited \n",
+    "range. If you really want to match the observation, then you would need to change the parameter ranges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.PARAMS['prcp_scaling_factor_min'], cfg.PARAMS['prcp_scaling_factor_max']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overparameteristion or the magic choice of the best calibration option:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We found already some combinations that equally well match the average MB. As we only use only one observation per glacier (i.e. per default the average geodetic MB from 2000-2020), but have up to three free MB model parameters, the MB model is overparameterised. Let's look a bit more systematically into that:\n",
+    "\n",
+    "We will use a range of different `prcp_fac` and then calibrate the `melt_f` accordingly to always match to the default average MB (`ref_mb`) over the reference period (`ref_period`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# calibrate the melt_f and annual MB \n",
+    "melt_f_dict = {}\n",
+    "spec_mb_prcp_fac_sens_dict = {}\n",
+    "\n",
+    "for prcp_fac in np.arange(0.1,5.0,0.5):\n",
+    "    calib_param = mb_calibration_from_geodetic_mb(gdir, prcp_scaling_factor=prcp_fac, overwrite_gdir=True)\n",
+    "    melt_f_dict[prcp_fac] = calib_param['melt_f']\n",
+    "    mb_prcp_fac_sens = massbalance.MonthlyTIModel(gdir)\n",
+    "    # ok, we actually matched the new ref_mb\n",
+    "    spec_mb_prcp_fac_sens_dict[prcp_fac] = mb_prcp_fac_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors_prcp_fac = plt.get_cmap('viridis_r').colors[20::25]\n",
+    "plt.figure()\n",
+    "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
+    "    plt.plot(prcp_fac, melt_f_dict[prcp_fac], 'o', color=colors_prcp_fac[j])\n",
+    "plt.ylabel(r'melt_f (kg m$^{-2}$ month$^{-1}$ K$^{-1}$)')\n",
+    "plt.xlabel('prcp_fac')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The larger the chosen `prcp_fac`, the larger is the calibrated `melt_f` when matching to the same average MB. \n",
+    "\n",
+    "What is the influence on the chosen parameter combination on other estimates than the average MB?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "colors_prcp_fac = plt.get_cmap('viridis_r').colors[20::25]\n",
+    "plt.figure()\n",
+    "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
+    "    plt.plot(np.arange(2000,2020,1),\n",
+    "             spec_mb_prcp_fac_sens_dict[prcp_fac], '-', color=colors_prcp_fac[j], label=prcp_fac)\n",
+    "plt.plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
+    "        label='observed in-situ')\n",
+    "plt.ylabel('Annual mass-balance (kg m-2)')\n",
+    "plt.xlabel('Year')\n",
+    "plt.legend(title='prcp_fac:', bbox_to_anchor=(1,1))\n",
+    "plt.xticks(np.arange(2000,2020,2));\n",
+    "plt.title(gdir.rgi_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The larger `prcp_fac` and `melt_f`, the larger is the interannual MB variability. For glaciers with in-situ observations, we can find a combination of `prcp_fac` and `melt_f` that has a similar interannnual MB variability than the observations (for example by choosing the combination with the most similar standard deviation of interanual MB variability, see [Schuster et al., 2023]())."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**We can also fix the `prcp_fac` and change the `temp_b` and `melt_f` instead:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "melt_f_dict_tb = {}\n",
+    "spec_mb_temp_b_sens_dict = {}\n",
+    "\n",
+    "for temp_bias in np.arange(-5,5.0,0.5):\n",
+    "    # for too negative temp_bias, no melt_f is found that matches the observations. We would need to \n",
+    "    # change the prcp_fac , but here we will just look\n",
+    "    # at those combinations where calibration works with a fixed prcp_fac. \n",
+    "    try:\n",
+    "        calib_param = mb_calibration_from_geodetic_mb(gdir, temp_bias=temp_bias, overwrite_gdir=True)\n",
+    "        melt_f_dict_tb[temp_bias] = calib_param['melt_f']\n",
+    "        mb_temp_b_sens = massbalance.MonthlyTIModel(gdir)\n",
+    "        # ok, we actually matched the new ref_mb\n",
+    "        spec_mb_temp_b_sens_dict[temp_bias] = mb_temp_b_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n",
+    "    except RuntimeError: #, 'RGI60-11.00897: ref mb not matched. Try to set calibrate_param2'\n",
+    "        pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# let's get a nice colormap centered at temp_bias=0\n",
+    "import matplotlib\n",
+    "norm = matplotlib.colors.Normalize(vmin=-5, vmax=5.01)\n",
+    "colors_temp_bias = plt.get_cmap('coolwarm')\n",
+    "\n",
+    "plt.figure()\n",
+    "for j,temp_bias in enumerate(melt_f_dict_tb.keys()):\n",
+    "    plt.plot(temp_bias, melt_f_dict_tb[temp_bias], 'o',\n",
+    "             color=colors_temp_bias(norm(temp_bias))) #colors_temp_bias[j])\n",
+    "plt.ylabel(r'melt_f (kg m$^{-2}$ month$^{-1}$ K$^{-1}$)')\n",
+    "plt.xlabel('temp_bias (°C)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A lower `melt_f` is needed if a positive `temp_bias` is applied!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure()\n",
+    "for temp_bias in melt_f_dict_tb.keys():\n",
+    "    plt.plot(np.arange(2000,2020,1),\n",
+    "             spec_mb_temp_b_sens_dict[temp_bias], '-', \n",
+    "             color=colors_temp_bias(norm(temp_bias)),\n",
+    "             label=temp_bias)\n",
+    "plt.plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
+    "        label='observed in-situ')\n",
+    "plt.ylabel('Annual mass-balance (kg m-2)')\n",
+    "plt.xlabel('Year')\n",
+    "plt.legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
+    "plt.xticks(np.arange(2000,2020,2));\n",
+    "plt.title(gdir.rgi_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the interannual MB variability gets smaller when large positive temperature biases are applied. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Take home points"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- We illustrated how a mass-balance (MB) model of a glacier can be calibrated in OGGM.  \n",
+    "- We can use different observational data for calibration: \n",
+    "    - calibrating to geodetic observations using different time periods, to in-situ direct glaciological observations from the WGMS (if available) or to other custom MB data.  \n",
+    "- There exist different ways of calibrating to the average observational data:\n",
+    "    - default is to calibrate the `melt_f`, and having the `prcp_fac` and `temp_bias` fixed. If the calibration does not work, the `temp_bias` is varied aswell. This is the option that is used operationally in OGGM in the preprocessed levels >=3 for all glaciers world-wide.\n",
+    "    - you can also calibrate instead `prcp_fac` or `temp_bias` and fix the other parameters.\n",
+    "    - However, we showed that the parameter combination choice has an influence on other estimates than the average MB. The model parameter calibration choice can also impact future volume and runoff projections. If you are further interested in that you can have a look into [Schuster et al., 2023]() which analyses the \"Glacier projections sensitivity to temperature-index model choices and calibration strategies\". \n",
+    "- As user of OGGM, you will most likely just use the default calibration option. However, it is good to be aware of the overparameterisation problem. In addition, if you want to include uncertainties of the MB model calibration, you could include additional experiments that use another calibration option. With more available observational data or improved climate data, you might also be able to use better ways to calibrate the MB model parameters. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next?\n",
+    "- return to the [OGGM documentation](https://docs.oggm.org)\n",
+    "- back to the [table of contents](welcome.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "nbTranslate": {
+   "displayLangs": [
+    "*"
+   ],
+   "hotkey": "alt-t",
+   "langInMainMenu": true,
+   "sourceLang": "en",
+   "targetLang": "fr",
+   "useGoogleTranslate": true
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/massbalance_calibration_oggm_v16.ipynb
+++ b/notebooks/massbalance_calibration_oggm_v16.ipynb
@@ -11,23 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default mass-balance (MB) model of OGGM is a very standard [temperature index melt model](https://www.sciencedirect.com/science/article/pii/S0022169403002579). At the beginning, OGGM had a very complicated calibration procedure where the glaciers with in-situ data were calibrated and then a so-called *tstar* got interpolated for glaciers without observations (see the [original publication](https://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html)). This method was very powerful, however, as new observational datasets emerged, we can finally calibrate on a glacier-per-glacier basis. With the new era of geodetic observations, OGGM uses per default the average geodetic observations from Jan 2000--Jan 2020 of [Hugonnet al. 2021](https://www.nature.com/articles/s41586-021-03436-z), that are now available for every glacier world-wide. \n",
+    "The default mass-balance (MB) model of OGGM is a very standard [temperature index melt model](https://www.sciencedirect.com/science/article/pii/S0022169403002579). At the beginning, OGGM had a very complicated calibration procedure where the glaciers with in-situ data were calibrated and then a so-called *tstar* got interpolated for glaciers without observations (see the [original publication](https://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html)). This method was very powerful, however, as new observational datasets emerged, we can finally calibrate on a glacier-per-glacier basis. With the new era of geodetic observations, OGGM uses per default the average geodetic observations from Jan 2000--Jan 2020 of [Hugonnet al. 2021](https://www.nature.com/articles/s41586-021-03436-z), that are now available for almost every glacier world-wide. \n",
     "\n",
     "In this tutorial, we will:\n",
-    "- introduce the default calibration procedure \n",
-    "- show how we can calibrate on other data (e.g. from direct glaciological observations from a glacier with in-situ observations) \n",
-    "- show the influence of different calibration options and explain the overparameterisation problem (more explanations in [Schuster et al., 2023]())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "TODO: \n",
-    "- add links to Schuster et al., 2023 preprint\n",
-    "- add other example glacier(s) where in situ-mb != geodetic MB\n",
-    "- add something about the regional dependence of the temperature bias and the way it is used in the OGGM preprocessed levels>=3 \n",
-    "- maybe make the structure a bit easier to read? "
+    "- [introduce the new default calibration procedure](#Default-calibration-(OGGM->=v1.6)) \n",
+    "- [show how to calibrate on glaciers with in-situ observations](#Other-calibration-options-for-glaciers-with-additional-observations)\n",
+    "- [show how to deal with errors and how to calibrate on other data](#Dealing-with-errors-and-including-your-own-mass-balance-observations)\n",
+    "- [show the influence of different calibration options and explain the overparameterisation problem](#Overparameteristion-or-the-magic-choice-of-the-best-calibration-option:) (more details are e.g. in [Schuster et al., 2023, in review]())"
    ]
   },
   {
@@ -44,13 +34,14 @@
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
+    "import matplotlib\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os\n",
     "\n",
     "import oggm\n",
     "from oggm import cfg, utils, workflow, tasks, graphics\n",
-    "from oggm.core import massbalance, climate\n",
+    "from oggm.core import massbalance\n",
     "from oggm.core.massbalance import mb_calibration_from_geodetic_mb"
    ]
   },
@@ -61,7 +52,6 @@
    "outputs": [],
    "source": [
     "cfg.initialize(logging_level='WARNING')\n",
-    "cfg.PARAMS['monthly_melt_f_max'] = 500 ## to do: remove this when this is changed per default\n",
     "cfg.PATHS['working_dir'] = utils.gettempdir(dirname='OGGM-calib-mb', reset=True)\n",
     "cfg.PARAMS['border'] = 10"
    ]
@@ -70,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start from two well known glaciers in the Austrian Alps, Kesselwandferner and Hintereisferner:"
+    "We start from two well known glaciers in the Austrian Alps, Kesselwandferner and Hintereisferner. But you can also choose any other other glacier, e.g. from [this list](https://github.com/OGGM/oggm-sample-data/blob/master/wgms/rgi_wgms_links_20220112.csv). "
    ]
   },
   {
@@ -79,21 +69,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# todo: select another glacier maybe in Pakistan without any MB observations\n",
     "# we start from preprocessing level 2\n",
-    "# in OGGM v1.6 you have to explicitly indacate the url from where you want to start from\n",
+    "# in OGGM v1.6 you have to explicitly indicate the url from where you want to start from\n",
     "# we will use here the elevation band flowlines which are much simpler than the centerlines\n",
     "base_url = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'\n",
     "            'L1-L2_files/elev_bands')\n",
-    "gdirs = workflow.init_glacier_directories(['RGI60-11.00787', 'RGI60-11.00897'], from_prepro_level=2,\n",
-    "                                         prepro_base_url=base_url)"
+    "gdirs = workflow.init_glacier_directories(['RGI60-11.00787',  'RGI60-11.00897'], from_prepro_level=2,\n",
+    "                                          prepro_base_url=base_url)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start from prepro_level 2, so we also need to process the climate ourselves:"
+    "We use the preprocessed level 2, so we also need to process the climate ourselves:"
    ]
   },
   {
@@ -102,6 +91,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# the climate that OGGM uses per default:\n",
     "cfg.PARAMS['baseline_climate']"
    ]
   },
@@ -111,8 +101,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# creates a climate file with the baseline climate, if you want to change the climate, you have to do that here, before the calibration!\n",
-    "workflow.execute_entity_task(tasks.process_climate_data, gdirs)"
+    "# creates a climate file with the baseline climate, \n",
+    "# if you want to change the climate, you have to do that,\n",
+    "# before the calibration!\n",
+    "workflow.execute_entity_task(tasks.process_climate_data, gdirs);"
    ]
   },
   {
@@ -128,22 +120,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f, ax = plt.subplots(figsize=(8, 8))\n",
-    "graphics.plot_googlemap(gdirs, ax=ax)"
+    "f, ax = plt.subplots(1,1,figsize=(6, 6))\n",
+    "graphics.plot_googlemap(gdirs[:2], ax=ax)\n",
+    "ax.set_title(gdirs[0].rgi_id + ' & ' + gdirs[1].rgi_id);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Default calibration (OGGM >=v1.6)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "**Let's apply the default mass-balance calibration:**"
+    "## Default mass-balance calibration (OGGM >=v1.6)"
    ]
   },
   {
@@ -175,9 +161,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output shows you the calibrated MB model parameters. Between the two glaciers, only the `melt_f` changed. In the default option, the precipitation factor (`prcp_fac`), depends on the average winter precipitation which is the same for the two neighbouring glaciers (they get their climate from the same climate gridpoint). \n",
+    "The output shows you the calibrated MB model parameters, the used observed reference MB for the calibration (`ref_mb`), the time period and the climate source. Between the two glaciers, only the `melt_f` changed. In the default option, the precipitation factor (`prcp_fac`), depends on the average winter precipitation which is the same for the two neighbouring glaciers (they get their climate from the same climate gridpoint). \n",
     "\n",
-    "The following figure shows the used relationship between winter precipitation and precipitation factor. It was calibrated by matching both, `melt_f` and `prcp_fac`, to match the average geodetic and winter MB on around 100 glaciers with both informations available. The found relationship of decreasing `prcp_fac` for increasing winter precipitation makes sense, as glaciers with already a large winter precipitation should not be corrected with a large multiplicative `prcp_fac`.  "
+    "The following figure shows the used relationship between winter precipitation and precipitation factor. It was calibrated by adapting `melt_f` and `prcp_fac` to match the average geodetic and winter MB on around 100 glaciers with both informations available. The found relationship of decreasing `prcp_fac` for increasing winter precipitation makes sense, as glaciers with already a large winter precipitation should not be corrected with a large multiplicative `prcp_fac`.  "
    ]
   },
   {
@@ -186,16 +172,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from oggm.utils import clip_array\n",
     "w_prcp_array = np.arange(0.5,20,1)\n",
+    "# we basically do here the same as in massbalance.decide_winter_precip_factor(gdir)\n",
     "a, b = cfg.PARAMS['winter_prcp_factor_ab']\n",
     "r0, r1 = cfg.PARAMS['winter_prcp_factor_range']\n",
-    "\n",
     "prcp_fac = a * np.log(w_prcp_array) + b\n",
     "# don't allow extremely low/high prcp. factors!!!\n",
-    "prcp_fac_array = clip_array(prcp_fac, r0, r1)\n",
+    "prcp_fac_array = utils.clip_array(prcp_fac, r0, r1)\n",
     "plt.plot(w_prcp_array, prcp_fac_array)\n",
-    "plt.xlabel('winter daily mean precipitation (kg m-2 day-1)')\n",
+    "plt.xlabel(r'winter daily mean precipitation (kg m$^{-2}$ day$^{-1}$)')\n",
     "plt.ylabel('precipitation factor (prcp_fac)');"
    ]
   },
@@ -205,7 +190,23 @@
    "source": [
     "In the default calibration option, we don't apply a temperature bias (`temp_bias`), which could potentially correct the climate to the local scale. However, we will change the three MB model parameters (`melt_f`, `temp_bias` and `prcp_fac`) later and see their influence on the calibration. \n",
     "\n",
-    "There are also some global MB parameters (`mb_global_params`), which we assume to be the same globally. These parameters were found to represent best the in-situ observations during a cross-validation using glaciers with additional observations. Of course, they could also be different for different glaciers, but this is another story!"
+    "There are also some global MB parameters (`mb_global_params`), which we assume to be the same globally. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdirs[-1].read_json('mb_calib')['mb_global_params']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These global MB parameter values were found to represent best the in-situ observations during a cross-validation for glaciers with additional observations. Of course, they could also be changed for different glaciers, but this would need even more data to justify the differences! The influence of using a different temperature lapse rate gradient to the default -0.0065 K/km are analysed in [Schuster et al. (2023, in review)]()."
    ]
   },
   {
@@ -226,7 +227,7 @@
     "    mean_mb = mbmod.get_specific_mb(fls=gdir.read_pickle('inversion_flowlines'),\n",
     "                                               year=np.arange(2000,2020,1)).mean()\n",
     "    print(gdir.rgi_id, f': average MB 2000-2020 = {mean_mb:.1f} kg m-2, ',\n",
-    "          f\"melt_f: {gdir.read_json('mb_calib')['melt_f']:.1f}\")"
+    "          f\"melt_f: {gdir.read_json('mb_calib')['melt_f']:.1f} kg m-2 day-1 K-1\")"
    ]
   },
   {
@@ -240,10 +241,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "*To simplify things, we will now focus just on one glacier:*\n",
+    "*To simplify things, we will now focus just on one glacier (Hintereisferner), but you can repeat it of course with other glaciers:*\n",
     "\n",
     "Let's check if the calibration worked: \n",
-    "- We will get first the average modelled MB"
+    "- We will get first the average modelled MB,"
    ]
   },
   {
@@ -252,9 +253,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdir = gdirs[-1]\n",
-    "h, w = gdir.get_inversion_flowline_hw()\n",
-    "mb_geod = massbalance.MonthlyTIModel(gdir)\n",
+    "gdir_hef = gdirs[1]\n",
+    "h, w = gdir_hef.get_inversion_flowline_hw()\n",
+    "mb_geod = massbalance.MonthlyTIModel(gdir_hef)\n",
     "# Note, if you change cfg.PARAMS['geodetic_mb_period'], you need to change the years here as well!\n",
     "mbdf= pd.DataFrame(index = np.arange(2000,2020,1))\n",
     "mbdf['mod_mb'] = mb_geod.get_specific_mb(h, w, year=mbdf.index)\n",
@@ -265,7 +266,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- then get the observed geodetic MB that we calibrated our mass-balance to:"
+    "- then get the observed geodetic MB that we calibrated our mass-balance to."
    ]
   },
   {
@@ -274,25 +275,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_geod_mb = utils.get_geodetic_mb_dataframe().loc[gdir.rgi_id]\n",
-    "ref_geod_mb"
+    "print('reference MB: ' + str(gdir_hef.read_json('mb_calib')['reference_mb'])+ ' kg m-2')\n",
+    "print('reference MB uncertainties: '+ str(gdir_hef.read_json('mb_calib')['reference_mb_err'])+ ' kg m-2')\n",
+    "print('reference MB time period: ' + gdir_hef.read_json('mb_calib')['reference_period'])\n",
+    "# if you use the default calibration data from Hugonnet et al., 2021, \n",
+    "# you can also get the geodetic data from any glacier from here:\n",
+    "# ref_geod_mb = utils.get_geodetic_mb_dataframe().loc[gdir_hef.rgi_id]\n",
+    "# ref_geod_mb_period = ref_geod_mb.loc[ref_geod_mb.period==cfg.PARAMS['geodetic_mb_period']].dmdtda*1000"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "   - We calibrated on the entire 20-yr time period, because then the observational uncertainties are smallest (in the table called: `err_dmdtda`)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_geod_mb_period = ref_geod_mb.loc[ref_geod_mb.period==cfg.PARAMS['geodetic_mb_period']].dmdtda*1000\n",
-    "ref_geod_mb_period"
+    "   - We calibrated on the entire 20-yr time period, because then the observational uncertainties are smallest."
    ]
   },
   {
@@ -302,7 +298,7 @@
    "outputs": [],
    "source": [
     "# this tests if the two parameters are very similar:\n",
-    "np.testing.assert_allclose(ref_geod_mb_period, mbdf['mod_mb'].mean())"
+    "np.testing.assert_allclose(gdir_hef.read_json('mb_calib')['reference_mb'], mbdf['mod_mb'].mean())"
    ]
   },
   {
@@ -311,7 +307,7 @@
    "source": [
     "Perfect! Our MB model reproduces the average observed MB, so the calibrated worked!\n",
     "\n",
-    "We have calibrated the `melt_f` to match the average geodetic observation and fixed the other parameters. We will now instead fix the `melt_f` and the `prcp_fac` and use the `temp_bias` as free variable for calibration."
+    "We have calibrated the `melt_f` to match the average geodetic observation and fixed the other parameters. We will now instead fix the `melt_f` and the `prcp_fac`, and use the `temp_bias` as free variable for calibration (by overwriting the default value of `calibrate_param1`)."
    ]
   },
   {
@@ -321,12 +317,13 @@
    "outputs": [],
    "source": [
     "# Let's calibrate on the temp_bias instead\n",
-    "# overwrite_gdir has to be set to True, because we want to overwrite the old calibration\n",
-    "mb_calibration_from_geodetic_mb(gdir,\n",
+    "# overwrite_gdir has to be set to True,\n",
+    "# because we want to overwrite the old calibration\n",
+    "mb_calibration_from_geodetic_mb(gdir_hef,\n",
     "                                calibrate_param1='temp_bias',\n",
     "                                overwrite_gdir=True)\n",
     "\n",
-    "mb_temp_b = massbalance.MonthlyTIModel(gdir)\n",
+    "mb_temp_b = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf['mod_mb_temp_b'] = mb_temp_b.get_specific_mb(h, w, year=mbdf.index)"
    ]
   },
@@ -343,15 +340,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
-    "gdir.read_json('mb_calib')"
+    "gdir_hef.read_json('mb_calib')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we used the median melt_f (i.e. 180 kg m-2 month-1 K-1) and changed the temperature bias until the average reference MB is matched. As the `melt_f` is lower than in the previous calibration option, we need to have a positive `temp_bias` to get to the same average MB."
+    "Here we used the median `melt_f` (i.e., 5 kg m-2 day-1 K-1) and changed `temp_bias` until the `reference MB` is matched. As the `melt_f` is lower than in the previous calibration option, we need to have a positive `temp_bias` to get to the same average MB."
    ]
   },
   {
@@ -368,14 +364,15 @@
    "outputs": [],
    "source": [
     "# Let's calibrate on the prcp_fac instead\n",
-    "# overwrite_gdir has to be set to True, because we want to overwrite the old calibration\n",
-    "mb_calibration_from_geodetic_mb(gdir,\n",
+    "# overwrite_gdir has to be set to True,\n",
+    "# because we want to overwrite the old calibration\n",
+    "mb_calibration_from_geodetic_mb(gdir_hef,\n",
     "                                calibrate_param1='prcp_fac',\n",
     "                                overwrite_gdir=True)\n",
     "\n",
-    "mb_prcp_fac = massbalance.MonthlyTIModel(gdir)\n",
+    "mb_prcp_fac = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf['mod_mb_prcp_fac'] = mb_prcp_fac.get_specific_mb(h, w, year=mbdf.index)\n",
-    "gdir.read_json('mb_calib')"
+    "gdir_hef.read_json('mb_calib')"
    ]
   },
   {
@@ -392,14 +389,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mbdf['in_situ_mb'] = gdir.get_ref_mb_data().loc[2000:2019]['ANNUAL_BALANCE']"
+    "mbdf['in_situ_mb'] = gdir_hef.get_ref_mb_data().loc[2000:2019]['ANNUAL_BALANCE']\n",
+    "# if we want to compare the average to the average geodetic MB, we need to have all years available\n",
+    "assert len(mbdf['in_situ_mb']) == 20"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's plot how well we match the interannual observations for the different options:"
+    "Let's plot how well we match the interannual observations for the different calibration options:"
    ]
   },
   {
@@ -425,7 +424,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this glacier, over the same time period (here 2000-2020), the average MB is quite similar between the geodetic and in-situ observation and could even be explained by the fact that the in-situ observations are in hydrological years (starting in October of the previous year) and the geodetic observations are in calendar years. If you repeat the analysis for another glacier (e.g. TODO), you will see larger discrepancies. You can also see, that the annual MB is different between the years and we will analyse this more systematically later! "
+    "For this glacier, over the same time period (here 2000-2020), the average MB is quite similar between the geodetic and in-situ observation and could even be explained by the fact that the in-situ observations are in hydrological years (starting in October of the previous year) and the geodetic observations are in calendar years. If you repeat the analysis for other glaciers with in-situ observations over that time period, you might see larger discrepancies. \n",
+    "\n",
+    "You can also see, that there are differences in the annual MB between the calibration options and the in-situ observations. We will analyse these differences more systematically later! "
    ]
   },
   {
@@ -441,9 +442,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, but actually you might trust the in-situ observations much more than the geodetic observation. So if you are only interested in glaciers with these in-situ observations, you can also use the in-situ observations for calibration. We will also calibrate instead over the entire time period.  \n",
+    "Ok, but actually you might trust the in-situ observations much more than the geodetic observation. So if you are only interested in glaciers with these in-situ observations, you can also use the in-situ observations for calibration. This might allow you also to calibrate over a longer time period and to use additional informations (such as the interannual MB variability, seasonal MB, ...). However, bare in mind that there are often gaps in the in-situ MB time series and make sure that you calibrate to the same modelled time period!\n",
     "\n",
-    "Attention: For the Hintereisferner glacier with a 70-year long time series, the assumption that we make, i.e., that the area does not change over the time period, gets more problematic. So think twice before repeating this at home!"
+    "Attention: For the Hintereisferner glacier with an almost 70-year long time series, the assumption that we make, i.e., that the area does not change over the time period, gets more problematic. So think twice before repeating this at home!"
    ]
   },
   {
@@ -452,10 +453,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mbdf_in_situ = gdir.get_ref_mb_data()\n",
+    "mbdf_in_situ = gdir_hef.get_ref_mb_data()\n",
     "mbdf_in_situ['ref_mb'] = mbdf_in_situ['ANNUAL_BALANCE']\n",
     "ref_mb = mbdf_in_situ.ref_mb.mean()\n",
-    "ref_period = f'{mbdf_in_situ.index[0]}-01-01_{mbdf_in_situ.index[-1] + 1}-01-01'"
+    "ref_period = f'{mbdf_in_situ.index[0]}-01-01_{mbdf_in_situ.index[-1] + 1}-01-01'\n",
+    "# check that every year between the beginning and the end has MB observations \n",
+    "assert len(mbdf_in_situ.index) == (mbdf_in_situ.index[-1] - mbdf_in_situ.index[0] + 1)"
    ]
   },
   {
@@ -473,8 +476,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mb_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb, ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True)\n",
-    "mb_in_situ_obs = massbalance.MonthlyTIModel(gdir)"
+    "mb_calibration_from_geodetic_mb(gdir_hef, ref_mb=ref_mb, ref_period=ref_period,\n",
+    "                                overwrite_gdir=True, write_to_gdir=True)\n",
+    "mb_in_situ_obs = massbalance.MonthlyTIModel(gdir_hef)"
    ]
   },
   {
@@ -484,9 +488,11 @@
    "outputs": [],
    "source": [
     "mbdf_in_situ['mod_mb'] = mb_in_situ_obs.get_specific_mb(h, w, year=mbdf_in_situ.index)\n",
-    "plt.plot(mbdf_in_situ['ref_mb'], label='in-situ observations\\n'+f'average: {ref_mb:.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
+    "plt.plot(mbdf_in_situ['ref_mb'],\n",
+    "         label='in-situ observations\\n'+f'average: {ref_mb:.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
     "plt.plot(mbdf_in_situ['mod_mb'],\n",
-    "         label='modelled mass-balance\\nvia calibrating melt_f\\n'+f'average: {mbdf_in_situ.mod_mb.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "         label=('modelled mass-balance\\nvia calibrating melt_f\\n'\n",
+    "                +f'average: {mbdf_in_situ.mod_mb.mean():.1f} ' + r'kg m$^{-2}$'))\n",
     "\n",
     "plt.legend()\n",
     "plt.ylabel(r'specific mass-balance (kg m$^{-2}$)')\n",
@@ -497,8 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When we look, however, into the annual mass-balance time series we do see quite some discrepancies:\n",
-    "Although the average MB over the 70-year time period is mached, the interannual mass-balance variability is not matched. And also the correlation between modelled and observed annual MB is not perfect:"
+    "The average MB over the entire time period is matched as we calibrate to it. However, the interannual mass-balance variability is different. How well the modelled annual mass-balance time series matches the observations can be for example assessed by looking at the correlation between modelled and observed annual MB "
    ]
   },
   {
@@ -514,9 +519,136 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Include your own mass-balance observations and dealing with errors\n",
+    "or by looking into the standard deviation of interannual MB variability, where we see a much larger variability for the modelled MB:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mbdf_in_situ.std()[['ref_mb','mod_mb']]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Dealing with errors and including your own mass-balance observations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at another glacier, now in Central Asia, for example the Golubin glacier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdir_2 = workflow.init_glacier_directories(['RGI60-13.11609'], from_prepro_level=2,\n",
+    "                                         prepro_base_url=base_url)[0]\n",
     "\n",
-    "In the same way, you can also use your own mass-balance observations to calibrate the mass-balance model. We use here as an example, an unrealistically hight positive MB over a 10-year time period:\n"
+    "tasks.process_climate_data(gdir_2)\n",
+    "\n",
+    "f, ax = plt.subplots(1,1,figsize=(6, 6))\n",
+    "graphics.plot_googlemap([gdir_2], ax=ax)\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's calibrate that glacier:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_calibration_from_geodetic_mb(gdir_2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We got a `RuntimeError` that says that the `ref_mb` is not matched and that we should set `calibrate_param2`. What happened? \n",
+    "\n",
+    "Well, no `melt_f` parameter could be found in the given ranges to reproduce the given calibration data (`ref_mb`). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What are the current minimum and maximum ranges of the melt factor (unit: kg m-2 day-1 K-1)\n",
+    "cfg.PARAMS['melt_f_min'], cfg.PARAMS['melt_f_max']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
+   "source": [
+    "If we believe that our observations are true, maybe the climate or the processes represented by the MB model are erroneous. \n",
+    "\n",
+    "What can we do to still match the `ref_mb`? We can either change the `melt_f` ranges by setting other values to the parameters above or we can allow that another MB model parameter is changed (i.e., `calibrate_param2`). This is basically very similar to the three-step-calibration \n",
+    "first introduced in [Huss & Hock 2015](https://doi.org/10.3389/feart.2015.00054), but you can choose your parameter ranges and parameter order yourself. \n",
+    "\n",
+    "**To reduce these MB model calibration errors, we will first change the `melt_f`, fix it at the lower or upper limit, and then change the `temp_bias`. This step-wise calibration is also the option that is used operationally in OGGM>=v1.6 in the preprocessed levels >=3 for all glaciers world-wide!**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Allowing another parameter to change is done by defining calibrate_param2\n",
+    "mb_calibration_from_geodetic_mb(gdir_2, calibrate_param2='temp_bias')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `melt_f` is at the minimum value and temperature was corrected to more negative values to allow for the relatively weak negative MB.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Use your own or fake MB observations for calibration**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the same way, you can also use your own MB observations or fake data to calibrate the MB model. We use here as an example, an unrealistically high positive MB for the Hintereisferner over a 10-year time period. To allow the calibration to happen, we need again to set `calibrate_param2`! Here we will use the `prcp_fac` as second parameter for a change:"
    ]
   },
   {
@@ -527,17 +659,9 @@
    "source": [
     "ref_period = '2000-01-01_2010-01-01'\n",
     "ref_mb = 2000 # Let's use an unrealistically positive  mass-balance\n",
-    "mb_calibration_from_geodetic_mb(gdir, ref_mb=ref_mb,\n",
-    "                                ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We got a `RuntimeError` that says that the `ref_mb` is not matched and that we should set `calibrate_param2`. What happened? \n",
-    "Well, no `melt_f` parameter could be found in the given ranges that could create such\n",
-    "a positive `ref_mb`. "
+    "mb_calibration_from_geodetic_mb(gdir_hef, ref_mb=ref_mb,\n",
+    "                                ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True,\n",
+    "                               calibrate_param2='prcp_fac');\n"
    ]
   },
   {
@@ -546,93 +670,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# What are the current minimum and maximum ranges of the melt factor (unit: kg m-2 month-1 K-1)\n",
-    "cfg.PARAMS['monthly_melt_f_min'], cfg.PARAMS['monthly_melt_f_max']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "If we believe that our observations are true, maybe the climate or the processes represented by the MB model are erroneous. \n",
-    "\n",
-    "What can we do to still match the `ref_mb`? We can either change the `melt_f` ranges by setting other values to the parameters above or we can allow that another parameter is changed (i.e., `calibrate_param2`). This is basically very similar to the three-step-calibration \n",
-    "first introduced in [Huss & Hock 2015](https://doi.org/10.3389/feart.2015.00054), but you can choose your parameter ranges and parameter order yourself. \n",
-    "\n",
-    "For our example, we will first change the `melt_f` and then change the `temp_bias` (this is the option that is used operationally in OGGM in the preprocessed levels >=3 for all glaciers world-wide):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Allowing another parameter to change is done by defining calibrate_param2\n",
-    "mb_calibration_from_geodetic_mb(gdir,ref_mb=ref_mb,\n",
-    "                                ref_period=ref_period,\n",
-    "                                calibrate_param2='temp_bias',\n",
-    "                               overwrite_gdir=True)\n",
-    "\n",
-    "mb_new = massbalance.MonthlyTIModel(gdir)\n",
-    "# ok, we actually matched the new ref_mb\n",
+    "mb_new = massbalance.MonthlyTIModel(gdir_hef)\n",
+    "# ok, we actually matched the new ref_mb over the 10-yr period\n",
     "np.testing.assert_allclose(ref_mb,\n",
     "                           mb_new.get_specific_mb(h, w, year=np.arange(2000,2010,1)).mean())\n",
     "# Let's look at the calibrated parameters\n",
-    "gdir.read_json('mb_calib')"
+    "gdir_hef.read_json('mb_calib')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, in that case, the climate was too warm to allow for such a positive MB. Even the lowest possible `melt_f` did not create positive enough MB. So, as a next step the temperature was corrected by using a negative `temp_bias`."
+    "Ok, in that case, the climate was too warm to allow for such a positive MB. Even the smallest `melt_f` did not allow for such a positive MB. Therefore, the `prcp_fac` was increased to allow that more (solid) precipitation can occur. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Also the `temp_bias` has a limited range:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cfg.PARAMS['temp_bias_min'], cfg.PARAMS['temp_bias_max']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "So, if we increase the `ref_mb` even further, we might even need a third free parameter (i.e., `calibrate_param3`). \n",
-    "Let's try it out:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_mb = 3500\n",
-    "mb_calibration_from_geodetic_mb(gdir,ref_mb=ref_mb,\n",
-    "                                ref_period=ref_period,\n",
-    "                                calibrate_param2='temp_bias',\n",
-    "                                calibrate_param3='prcp_fac',\n",
-    "                               overwrite_gdir=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In that case, the minimum `melt_f` and the minimum `temp_bias` are applied. The `prcp_fac` is increased as this results in more solid precipitation. If you increased the `ref_mb` even further, the method will not find any combination as the `prcp_fac` also has a limited \n",
-    "range. If you really want to match the observation, then you would need to change the parameter ranges."
+    "However, also the `prcp_fac` has a limited range: "
    ]
   },
   {
@@ -648,6 +705,58 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "So, if we increase the `ref_mb` even further, we might even need a third free parameter (i.e., we need to set `calibrate_param3`). \n",
+    "Let's try it out, by using now the same order as in [Huss & Hock (2015)](https://doi.org/10.3389/feart.2015.00054) (but different allowed parameter changes that also depend on the chosen climate...):\n",
+    "\n",
+    "That means, we match the `ref_mb` by \n",
+    "- first trying to adapt `prcp_fac`,\n",
+    "- then `melt_f`,\n",
+    "- and finally `temp_bias`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_mb = 3500 # if you replace it with 4000, no combination of parameters can be found for that glacier\n",
+    "mb_calibration_from_geodetic_mb(gdir_hef,ref_mb=ref_mb,\n",
+    "                                ref_period=ref_period,\n",
+    "                                calibrate_param1='prcp_fac',\n",
+    "                                calibrate_param2='melt_f',\n",
+    "                                calibrate_param3='temp_bias',\n",
+    "                               overwrite_gdir=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In that case, the minimum `melt_f` and the maximum `prcp_fac` are applied. The `temp_bias` is set to a negative value as this results in more solid precipitation. If you increased the `ref_mb` even further, the method will not find any combination as the `temp_bias` also has a limited \n",
+    "range. If you really want to match the observation, then you would need to change the parameter ranges."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cfg.PARAMS['temp_bias_min'], cfg.PARAMS['temp_bias_max']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Overparameteristion or the magic choice of the best calibration option:"
    ]
   },
@@ -655,7 +764,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We found already some combinations that equally well match the average MB. As we only use only one observation per glacier (i.e. per default the average geodetic MB from 2000-2020), but have up to three free MB model parameters, the MB model is overparameterised. Let's look a bit more systematically into that:\n",
+    "We found already some combinations that equally well match the average MB over a given time period. As we only use only one observation per glacier (i.e., per default the average geodetic MB from 2000-2020), but have up to three free MB model parameters, the MB model is overparameterised. That means, there are in theory an infinite amount of calibration options possible that equally well match the one obervation. Let's look a bit more systematically into that:\n",
     "\n",
     "We will use a range of different `prcp_fac` and then calibrate the `melt_f` accordingly to always match to the default average MB (`ref_mb`) over the reference period (`ref_period`)."
    ]
@@ -667,15 +776,20 @@
    "outputs": [],
    "source": [
     "# calibrate the melt_f and annual MB \n",
-    "melt_f_dict = {}\n",
+    "pd_prcp_fac_sens = pd.DataFrame(index=np.arange(0.1,5.0,0.3))\n",
     "spec_mb_prcp_fac_sens_dict = {}\n",
-    "\n",
-    "for prcp_fac in np.arange(0.1,5.0,0.5):\n",
-    "    calib_param = mb_calibration_from_geodetic_mb(gdir, prcp_scaling_factor=prcp_fac, overwrite_gdir=True)\n",
-    "    melt_f_dict[prcp_fac] = calib_param['melt_f']\n",
-    "    mb_prcp_fac_sens = massbalance.MonthlyTIModel(gdir)\n",
+    "for prcp_fac in pd_prcp_fac_sens.index:\n",
+    "    calib_param = mb_calibration_from_geodetic_mb(gdir_hef,\n",
+    "                                                  prcp_scaling_factor=prcp_fac, overwrite_gdir=True)\n",
+    "    pd_prcp_fac_sens.loc[prcp_fac, 'melt_f'] = calib_param['melt_f']\n",
+    "    mb_prcp_fac_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
     "    # ok, we actually matched the new ref_mb\n",
-    "    spec_mb_prcp_fac_sens_dict[prcp_fac] = mb_prcp_fac_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n"
+    "    annual_mb = mb_prcp_fac_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n",
+    "    spec_mb_prcp_fac_sens_dict[prcp_fac] = annual_mb\n",
+    "    # let's also check how well the interannual MB variability is matched\n",
+    "    # by comparing the standard deviation of the annual MB to the observed one\n",
+    "    std_quot_annual_mb = annual_mb.std()/mbdf_in_situ.loc[2000:2019, 'ANNUAL_BALANCE'].std()\n",
+    "    pd_prcp_fac_sens.loc[prcp_fac, 'std_quot_annual_mb'] = std_quot_annual_mb"
    ]
   },
   {
@@ -684,19 +798,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "colors_prcp_fac = plt.get_cmap('viridis_r').colors[20::25]\n",
+    "# let's get some nice colors visualising more precipitation\n",
+    "colors_prcp_fac = plt.get_cmap('viridis_r').colors[10::10]\n",
     "plt.figure()\n",
     "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
-    "    plt.plot(prcp_fac, melt_f_dict[prcp_fac], 'o', color=colors_prcp_fac[j])\n",
-    "plt.ylabel(r'melt_f (kg m$^{-2}$ month$^{-1}$ K$^{-1}$)')\n",
-    "plt.xlabel('prcp_fac')"
+    "    plt.plot(prcp_fac, pd_prcp_fac_sens.loc[prcp_fac, 'melt_f'],\n",
+    "             'o', color=colors_prcp_fac[j])\n",
+    "plt.ylabel(r'melt_f (kg m$^{-2}$ day$^{-1}$ K$^{-1}$)')\n",
+    "plt.xlabel('prcp_fac');"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The larger the chosen `prcp_fac`, the larger is the calibrated `melt_f` when matching to the same average MB. \n",
+    "All these combinations match the average `ref_mb` equally. The larger the chosen `prcp_fac`, the larger needs to be the calibrated `melt_f` when matching to the same average MB.\n",
     "\n",
     "What is the influence on the chosen parameter combination on other estimates than the average MB?"
    ]
@@ -707,26 +823,52 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "colors_prcp_fac = plt.get_cmap('viridis_r').colors[20::25]\n",
     "plt.figure()\n",
     "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
     "    plt.plot(np.arange(2000,2020,1),\n",
-    "             spec_mb_prcp_fac_sens_dict[prcp_fac], '-', color=colors_prcp_fac[j], label=prcp_fac)\n",
-    "plt.plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
+    "             spec_mb_prcp_fac_sens_dict[prcp_fac], '-', \n",
+    "             color=colors_prcp_fac[j], label=f'{prcp_fac:.1f}')\n",
+    "plt.plot(mbdf_in_situ.loc[2000:2019].index,\n",
+    "         mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'],\n",
+    "         color='grey', lw=3, \n",
     "        label='observed in-situ')\n",
     "plt.ylabel('Annual mass-balance (kg m-2)')\n",
     "plt.xlabel('Year')\n",
-    "plt.legend(title='prcp_fac:', bbox_to_anchor=(1,1))\n",
+    "plt.legend(title='prcp_fac:', bbox_to_anchor=(1,1), fontsize=9)\n",
     "plt.xticks(np.arange(2000,2020,2));\n",
-    "plt.title(gdir.rgi_id)"
+    "plt.title(gdir_hef.rgi_id);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The larger `prcp_fac` and `melt_f`, the larger is the interannual MB variability. For glaciers with in-situ observations, we can find a combination of `prcp_fac` and `melt_f` that has a similar interannnual MB variability than the observations (for example by choosing the combination with the most similar standard deviation of interanual MB variability, see [Schuster et al., 2023]())."
+    "The larger the `prcp_fac` and the `melt_f`, the larger is the interannual MB variability. For glaciers with in-situ observations, we can find a combination of `prcp_fac` and `melt_f` that has a similar interannnual MB variability than the observations. For example, you can choose a MB model parameter combination where the standard deviation quotient of the annual the modelled and observed MB is near to 1: "
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "condi = (pd_prcp_fac_sens['std_quot_annual_mb'] < 1.1) & (pd_prcp_fac_sens['std_quot_annual_mb'] > 0.9)\n",
+    "pd_prcp_fac_sens[condi]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the Hintereisferner glacier, the best MB model combination to match the interannual MB variability would be for a `prcp_fac` between 1.6 and 1.9 and a `melt_f` between 6 and 6.5 (more in [Schuster et al., 2023, in review]())."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -749,9 +891,9 @@
     "    # change the prcp_fac , but here we will just look\n",
     "    # at those combinations where calibration works with a fixed prcp_fac. \n",
     "    try:\n",
-    "        calib_param = mb_calibration_from_geodetic_mb(gdir, temp_bias=temp_bias, overwrite_gdir=True)\n",
+    "        calib_param = mb_calibration_from_geodetic_mb(gdir_hef, temp_bias=temp_bias, overwrite_gdir=True)\n",
     "        melt_f_dict_tb[temp_bias] = calib_param['melt_f']\n",
-    "        mb_temp_b_sens = massbalance.MonthlyTIModel(gdir)\n",
+    "        mb_temp_b_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
     "        # ok, we actually matched the new ref_mb\n",
     "        spec_mb_temp_b_sens_dict[temp_bias] = mb_temp_b_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n",
     "    except RuntimeError: #, 'RGI60-11.00897: ref mb not matched. Try to set calibrate_param2'\n",
@@ -765,16 +907,15 @@
    "outputs": [],
    "source": [
     "# let's get a nice colormap centered at temp_bias=0\n",
-    "import matplotlib\n",
     "norm = matplotlib.colors.Normalize(vmin=-5, vmax=5.01)\n",
     "colors_temp_bias = plt.get_cmap('coolwarm')\n",
     "\n",
     "plt.figure()\n",
     "for j,temp_bias in enumerate(melt_f_dict_tb.keys()):\n",
     "    plt.plot(temp_bias, melt_f_dict_tb[temp_bias], 'o',\n",
-    "             color=colors_temp_bias(norm(temp_bias))) #colors_temp_bias[j])\n",
-    "plt.ylabel(r'melt_f (kg m$^{-2}$ month$^{-1}$ K$^{-1}$)')\n",
-    "plt.xlabel('temp_bias (°C)')"
+    "             color=colors_temp_bias(norm(temp_bias))) \n",
+    "plt.ylabel(r'melt_f (kg m$^{-2}$ day$^{-1}$ K$^{-1}$)')\n",
+    "plt.xlabel('temp_bias (°C)');"
    ]
   },
   {
@@ -802,14 +943,16 @@
     "plt.xlabel('Year')\n",
     "plt.legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
     "plt.xticks(np.arange(2000,2020,2));\n",
-    "plt.title(gdir.rgi_id)"
+    "plt.title(gdir_hef.rgi_id);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the interannual MB variability gets smaller when large positive temperature biases are applied. "
+    "And the interannual MB variability gets smaller when large positive `temp_bias` are applied. The parameter combination choice or calibration option also influences the modelled seasonal MB or elevation-dependent MB over the calibration period. Additionally, volume and runoff are influenced by the model parameter choice. If you are further interested in that you can have a look into [Schuster et al (2023, in review)](), which analyses the \"Glacier projections sensitivity to temperature-index model choices and calibration strategies\". \n",
+    "\n",
+    "Using prior knowledge on the MB model parameters by a Bayesian calibration scheme is a good option to constrain the parameter ranges. Like that you can also directly include the MB observation uncertainties and quantify the parameter uncertainties. You can read about that in [Rounce et al., 2020](https://doi.org/10.1017/jog.2019.91)!"
    ]
   },
   {
@@ -835,8 +978,8 @@
     "    - calibrating to geodetic observations using different time periods, to in-situ direct glaciological observations from the WGMS (if available) or to other custom MB data.  \n",
     "- There exist different ways of calibrating to the average observational data:\n",
     "    - default is to calibrate the `melt_f`, and having the `prcp_fac` and `temp_bias` fixed. If the calibration does not work, the `temp_bias` is varied aswell. This is the option that is used operationally in OGGM in the preprocessed levels >=3 for all glaciers world-wide.\n",
-    "    - you can also calibrate instead `prcp_fac` or `temp_bias` and fix the other parameters.\n",
-    "    - However, we showed that the parameter combination choice has an influence on other estimates than the average MB. The model parameter calibration choice can also impact future volume and runoff projections. If you are further interested in that you can have a look into [Schuster et al., 2023]() which analyses the \"Glacier projections sensitivity to temperature-index model choices and calibration strategies\". \n",
+    "    - you can also calibrate instead on `prcp_fac` or `temp_bias` and fix the other parameters.\n",
+    "    - However, we showed that the parameter combination choice has an influence on other estimates than the average MB. The model parameter calibration choice can also impact future volume and runoff projections (see [Schuster et al., 2023, in review]()). \n",
     "- As user of OGGM, you will most likely just use the default calibration option. However, it is good to be aware of the overparameterisation problem. In addition, if you want to include uncertainties of the MB model calibration, you could include additional experiments that use another calibration option. With more available observational data or improved climate data, you might also be able to use better ways to calibrate the MB model parameters. \n"
    ]
   },

--- a/notebooks/massbalance_calibration_oggm_v16.ipynb
+++ b/notebooks/massbalance_calibration_oggm_v16.ipynb
@@ -42,7 +42,7 @@
     "import oggm\n",
     "from oggm import cfg, utils, workflow, tasks, graphics\n",
     "from oggm.core import massbalance\n",
-    "from oggm.core.massbalance import mb_calibration_from_geodetic_mb"
+    "from oggm.core.massbalance import mb_calibration_from_scalar_mb\n"
    ]
   },
   {
@@ -77,6 +77,13 @@
     "gdirs = workflow.init_glacier_directories(['RGI60-11.00787',  'RGI60-11.00897'], from_prepro_level=2,\n",
     "                                          prepro_base_url=base_url)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -145,7 +152,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Per default the [Hugonnet et al. (2021)](https://www.nature.com/articles/s41586-021-03436-z) average geodetic observation is used over the entire time period Jan 2000 to Jan 2020 to calibrate the melt factor (`melt_f`) for every single glacier: "
+    "Per default the [Hugonnet et al. (2021)](https://www.nature.com/articles/s41586-021-03436-z) average geodetic observation is used over the entire time period Jan 2000 to Jan 2020 to calibrate the melt factor (`melt_f`) for every single glacier. This is done by `mb_calibration_from_scalar_mb` which determines the mass balance parameters from a scalar mass-balance value."
    ]
   },
   {
@@ -154,7 +161,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "workflow.execute_entity_task(mb_calibration_from_geodetic_mb, gdirs)"
+    "workflow.execute_entity_task(mb_calibration_from_scalar_mb, gdirs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if you want to know more about the different options and their meanings\n",
+    "# -> check out the docstring:\n",
+    "# mb_calibration_from_scalar_mb?"
    ]
   },
   {
@@ -174,8 +192,8 @@
    "source": [
     "w_prcp_array = np.arange(0.5,20,1)\n",
     "# we basically do here the same as in massbalance.decide_winter_precip_factor(gdir)\n",
-    "a, b = cfg.PARAMS['winter_prcp_factor_ab']\n",
-    "r0, r1 = cfg.PARAMS['winter_prcp_factor_range']\n",
+    "a, b = cfg.PARAMS['winter_prcp_fac_ab']\n",
+    "r0, r1 = cfg.PARAMS['winter_prcp_fac_range']\n",
     "prcp_fac = a * np.log(w_prcp_array) + b\n",
     "# don't allow extremely low/high prcp. factors!!!\n",
     "prcp_fac_array = utils.clip_array(prcp_fac, r0, r1)\n",
@@ -319,9 +337,9 @@
     "# Let's calibrate on the temp_bias instead\n",
     "# overwrite_gdir has to be set to True,\n",
     "# because we want to overwrite the old calibration\n",
-    "mb_calibration_from_geodetic_mb(gdir_hef,\n",
-    "                                calibrate_param1='temp_bias',\n",
-    "                                overwrite_gdir=True)\n",
+    "mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "                              calibrate_param1='temp_bias',\n",
+    "                              overwrite_gdir=True)\n",
     "\n",
     "mb_temp_b = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf['mod_mb_temp_b'] = mb_temp_b.get_specific_mb(h, w, year=mbdf.index)"
@@ -366,9 +384,9 @@
     "# Let's calibrate on the prcp_fac instead\n",
     "# overwrite_gdir has to be set to True,\n",
     "# because we want to overwrite the old calibration\n",
-    "mb_calibration_from_geodetic_mb(gdir_hef,\n",
-    "                                calibrate_param1='prcp_fac',\n",
-    "                                overwrite_gdir=True)\n",
+    "mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "                              calibrate_param1='prcp_fac',\n",
+    "                              overwrite_gdir=True)\n",
     "\n",
     "mb_prcp_fac = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf['mod_mb_prcp_fac'] = mb_prcp_fac.get_specific_mb(h, w, year=mbdf.index)\n",
@@ -453,12 +471,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "massbalance.mb_calibration_from_wgms_mb(gdir_hef, overwrite_gdir=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`mb_calibration_from_wgms_mb` is a short-cut function that uses internally `mb_calibration_from_scalar_mb`,\n",
+    "but uses directly the average annual in-situ MB observations from the WGMS. You can get them like that:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "mbdf_in_situ = gdir_hef.get_ref_mb_data()\n",
     "mbdf_in_situ['ref_mb'] = mbdf_in_situ['ANNUAL_BALANCE']\n",
-    "ref_mb = mbdf_in_situ.ref_mb.mean()\n",
-    "ref_period = f'{mbdf_in_situ.index[0]}-01-01_{mbdf_in_situ.index[-1] + 1}-01-01'\n",
     "# check that every year between the beginning and the end has MB observations \n",
-    "assert len(mbdf_in_situ.index) == (mbdf_in_situ.index[-1] - mbdf_in_situ.index[0] + 1)"
+    "assert len(mbdf_in_situ.index) == (mbdf_in_situ.index[-1] - mbdf_in_situ.index[0] + 1)\n",
+    "ref_mb = mbdf_in_situ.ref_mb.mean()"
    ]
   },
   {
@@ -467,7 +501,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f\"We will calibrate now the `melt_f` to match the observed average {ref_mb:.1f} kg m-2 over the time period {ref_period}\")"
+    "### There exist a short-cut function is to use \n",
+    "### it does the same thing as above in one line\n",
+    "### (i.e. it calibrates directly on the average in-situ observations"
    ]
   },
   {
@@ -476,17 +512,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mb_calibration_from_geodetic_mb(gdir_hef, ref_mb=ref_mb, ref_period=ref_period,\n",
-    "                                overwrite_gdir=True, write_to_gdir=True)\n",
-    "mb_in_situ_obs = massbalance.MonthlyTIModel(gdir_hef)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "mb_in_situ_obs = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf_in_situ['mod_mb'] = mb_in_situ_obs.get_specific_mb(h, w, year=mbdf_in_situ.index)\n",
     "plt.plot(mbdf_in_situ['ref_mb'],\n",
     "         label='in-situ observations\\n'+f'average: {ref_mb:.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
@@ -512,7 +538,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mbdf_in_situ.corr()['ref_mb']['mod_mb']\n"
+    "mbdf_in_situ[['ref_mb','mod_mb']].corr().values[0][1]"
    ]
   },
   {
@@ -574,7 +600,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's calibrate that glacier:"
+    "Let's calibrate that glacier (with the default average geodetic observation):"
    ]
   },
   {
@@ -583,7 +609,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mb_calibration_from_geodetic_mb(gdir_2)"
+    "mb_calibration_from_scalar_mb(gdir_2)\n",
+    "# you could also calibrate on the WGMS data instead\n",
+    "# as this glacier has in-situ MB observations\n",
+    "# massbalance.mb_calibration_from_wgms_mb(gdir_2, overwrite_gdir=True)"
    ]
   },
   {
@@ -627,7 +656,7 @@
    "outputs": [],
    "source": [
     "# Allowing another parameter to change is done by defining calibrate_param2\n",
-    "mb_calibration_from_geodetic_mb(gdir_2, calibrate_param2='temp_bias')"
+    "mb_calibration_from_scalar_mb(gdir_2, calibrate_param2='temp_bias')"
    ]
   },
   {
@@ -659,7 +688,7 @@
    "source": [
     "ref_period = '2000-01-01_2010-01-01'\n",
     "ref_mb = 2000 # Let's use an unrealistically positive  mass-balance\n",
-    "mb_calibration_from_geodetic_mb(gdir_hef, ref_mb=ref_mb,\n",
+    "mb_calibration_from_scalar_mb(gdir_hef, ref_mb=ref_mb,\n",
     "                                ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True,\n",
     "                               calibrate_param2='prcp_fac');\n"
    ]
@@ -698,7 +727,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cfg.PARAMS['prcp_scaling_factor_min'], cfg.PARAMS['prcp_scaling_factor_max']"
+    "cfg.PARAMS['prcp_fac_min'], cfg.PARAMS['prcp_fac_max']"
    ]
   },
   {
@@ -721,12 +750,12 @@
    "outputs": [],
    "source": [
     "ref_mb = 3500 # if you replace it with 4000, no combination of parameters can be found for that glacier\n",
-    "mb_calibration_from_geodetic_mb(gdir_hef,ref_mb=ref_mb,\n",
-    "                                ref_period=ref_period,\n",
-    "                                calibrate_param1='prcp_fac',\n",
-    "                                calibrate_param2='melt_f',\n",
-    "                                calibrate_param3='temp_bias',\n",
-    "                               overwrite_gdir=True)"
+    "mb_calibration_from_scalar_mb(gdir_hef,ref_mb=ref_mb,\n",
+    "                              ref_period=ref_period,\n",
+    "                              calibrate_param1='prcp_fac',\n",
+    "                              calibrate_param2='melt_f',\n",
+    "                              calibrate_param3='temp_bias',\n",
+    "                              overwrite_gdir=True)"
    ]
   },
   {
@@ -751,7 +780,11 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "### check out the docstring for more information about the options\n",
+    "### by uncommenting the line below:\n",
+    "# mb_calibration_from_scalar_mb?"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -779,8 +812,8 @@
     "pd_prcp_fac_sens = pd.DataFrame(index=np.arange(0.1,5.0,0.3))\n",
     "spec_mb_prcp_fac_sens_dict = {}\n",
     "for prcp_fac in pd_prcp_fac_sens.index:\n",
-    "    calib_param = mb_calibration_from_geodetic_mb(gdir_hef,\n",
-    "                                                  prcp_scaling_factor=prcp_fac, overwrite_gdir=True)\n",
+    "    calib_param = mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "                                                prcp_fac=prcp_fac, overwrite_gdir=True)\n",
     "    pd_prcp_fac_sens.loc[prcp_fac, 'melt_f'] = calib_param['melt_f']\n",
     "    mb_prcp_fac_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
     "    # ok, we actually matched the new ref_mb\n",
@@ -801,7 +834,7 @@
     "# let's get some nice colors visualising more precipitation\n",
     "colors_prcp_fac = plt.get_cmap('viridis_r').colors[10::10]\n",
     "plt.figure()\n",
-    "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
+    "for j,prcp_fac in enumerate(pd_prcp_fac_sens.index):\n",
     "    plt.plot(prcp_fac, pd_prcp_fac_sens.loc[prcp_fac, 'melt_f'],\n",
     "             'o', color=colors_prcp_fac[j])\n",
     "plt.ylabel(r'melt_f (kg m$^{-2}$ day$^{-1}$ K$^{-1}$)')\n",
@@ -824,7 +857,7 @@
    "outputs": [],
    "source": [
     "plt.figure()\n",
-    "for j,prcp_fac in enumerate(melt_f_dict.keys()):\n",
+    "for j,prcp_fac in enumerate(pd_prcp_fac_sens.index):\n",
     "    plt.plot(np.arange(2000,2020,1),\n",
     "             spec_mb_prcp_fac_sens_dict[prcp_fac], '-', \n",
     "             color=colors_prcp_fac[j], label=f'{prcp_fac:.1f}')\n",
@@ -832,7 +865,7 @@
     "         mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'],\n",
     "         color='grey', lw=3, \n",
     "        label='observed in-situ')\n",
-    "plt.ylabel('Annual mass-balance (kg m-2)')\n",
+    "plt.ylabel(r'Annual mass-balance (kg m$^{-2}$)')\n",
     "plt.xlabel('Year')\n",
     "plt.legend(title='prcp_fac:', bbox_to_anchor=(1,1), fontsize=9)\n",
     "plt.xticks(np.arange(2000,2020,2));\n",
@@ -891,7 +924,7 @@
     "    # change the prcp_fac , but here we will just look\n",
     "    # at those combinations where calibration works with a fixed prcp_fac. \n",
     "    try:\n",
-    "        calib_param = mb_calibration_from_geodetic_mb(gdir_hef, temp_bias=temp_bias, overwrite_gdir=True)\n",
+    "        calib_param = mb_calibration_from_scalar_mb(gdir_hef, temp_bias=temp_bias, overwrite_gdir=True)\n",
     "        melt_f_dict_tb[temp_bias] = calib_param['melt_f']\n",
     "        mb_temp_b_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
     "        # ok, we actually matched the new ref_mb\n",
@@ -939,7 +972,7 @@
     "             label=temp_bias)\n",
     "plt.plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
     "        label='observed in-situ')\n",
-    "plt.ylabel('Annual mass-balance (kg m-2)')\n",
+    "plt.ylabel(r'Annual mass-balance (kg m$^{-2}$)')\n",
     "plt.xlabel('Year')\n",
     "plt.legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
     "plt.xticks(np.arange(2000,2020,2));\n",

--- a/notebooks/run_with_a_spinup_and_gcm_data.ipynb
+++ b/notebooks/run_with_a_spinup_and_gcm_data.ipynb
@@ -216,7 +216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/notebooks/run_with_gcm_oggm_v16.ipynb
+++ b/notebooks/run_with_gcm_oggm_v16.ipynb
@@ -1,0 +1,456 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run OGGM with GCM data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this example, we illustrate how to do a typical \"projection run\", i.e. using GCM data. Here we will first use already bias-corrected CMIP6 data from [ISIMIP3b](https://www.isimip.org/gettingstarted/isimip3b-bias-adjustment/), but also show alternatives when using pure CMIP5 or CMIP6 data. There are two important steps:\n",
+    "- simulate all glaciers from their inventory date up to a \"present day\" geometry, i.e., until the end of the applied climate dataset (end of 2019) used for calibration (**New from OGGM version 1.4 onwards: this is already available in the pre-processed directories**)\n",
+    "- simulate their future evolution from the present day state (2020-2100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Libs\n",
+    "import xarray as xr\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Locals\n",
+    "import oggm.cfg as cfg\n",
+    "from oggm import utils, workflow, tasks\n",
+    "from oggm.shop import gcm_climate"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Pre-processed directories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's do a run for two Himalayan glaciers: Ngojumba and Khumbu."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize OGGM and set up the default run parameters\n",
+    "cfg.initialize(logging_level='WARNING')\n",
+    "\n",
+    "# Here we override some of the default parameters\n",
+    "# How many grid points around the glacier?\n",
+    "# Make it large if you expect your glaciers to grow large:\n",
+    "# here, 80 is more than enough\n",
+    "cfg.PARAMS['border'] = 80 # maybe change it back to 10\n",
+    "\n",
+    "# Local working directory (where OGGM will write its output)\n",
+    "cfg.PATHS['working_dir'] = utils.gettempdir('OGGM_gcm_run', reset=True)\n",
+    "\n",
+    "# RGI glaciers: Ngojumba and Khumbu\n",
+    "rgi_ids = utils.get_rgi_glacier_entities(['RGI60-15.03473', 'RGI60-15.03733'])\n",
+    "\n",
+    "# Go - get the pre-processed glacier directories\n",
+    "# in OGGM v1.6 you have to explicitly indicate the url from where you want to start from\n",
+    "# we will use here the elevation band flowlines which are much simpler than the centerlines\n",
+    "base_url = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'\n",
+    "            'exps/L3-L5_files/W5E5_melt_calib')\n",
+    "gdirs = workflow.init_glacier_directories(rgi_ids, from_prepro_level=5,\n",
+    "                                         prepro_base_url=base_url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## New in version 1.4: the `_historical` runs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As of v1.4, the level 5 files now come with a pre-computed model run from the RGI outline date to the last possible date given by the historical climate data. In case of the new default climate dataset [GSWP3_W5E5](https://www.isimip.org/gettingstarted/input-data-bias-adjustment/details/80/), this is until the end of 2019, so the volume is computed until the beginning of 2020. These files are stored in the directory with a `_historical` suffix. Let's compile them for our two glaciers: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = utils.compile_run_output(gdirs, input_filesuffix='_historical')\n",
+    "ds.volume.plot(hue='rgi_id');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Each RGI glacier has an \"inventory date\", the time at which the ouline is valid. It can change between glaciers:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdirs[0].rgi_date, gdirs[1].rgi_date"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.time[-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The command that was run on preprocessing was the [run_from_climate_data](https://docs.oggm.org/en/stable/generated/oggm.tasks.run_from_climate_data.html#oggm.tasks.run_from_climate_data) which will run OGGM from this inventory date up to a desired date (here, the last year with valid historical climate data). So the data above is strictly equivalent to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow.execute_entity_task(tasks.run_from_climate_data, gdirs, \n",
+    "                             output_filesuffix='_my_spinup',  # to use the files as input later on\n",
+    "                            );\n",
+    "ds = utils.compile_run_output(gdirs, input_filesuffix='_my_spinup')\n",
+    "ds.volume.plot(hue='rgi_id');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One thing to remember here is that although we try hard to avoid spin-up issues, the glacier after the inversion is not in a perfect dynamical state. Some variable (in particular glacier length) might need some years to adjust:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.length.plot(hue='rgi_id');"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download and process GCM data from ISIMIP3b (bias-corrected CMIP6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# you can choose one of these 5 different GCMs:\n",
+    "#['gfdl-esm4_r1i1p1f1', 'ipsl-cm6a-lr_r1i1p1f1',\n",
+    "# 'mpi-esm1-2-hr_r1i1p1f1', 'mri-esm2-0_r1i1p1f1',\n",
+    "# 'ukesm1-0-ll_r1i1p1f2']\n",
+    "ensemble = 'mri-esm2-0_r1i1p1f1' \n",
+    "\n",
+    "for ssp in ['ssp126', 'ssp370','ssp585']:\n",
+    "    # bias correct them\n",
+    "    workflow.execute_entity_task(gcm_climate.process_monthly_isimip_data, gdirs, \n",
+    "                                 ssp = ssp,\n",
+    "                                 # gcm ensemble -> you can choose another one\n",
+    "                                 ensemble=ensemble,\n",
+    "                                 # recognize the climate file for later\n",
+    "                                 output_filesuffix=f'_ISIMIP3b_{ensemble}_{ssp}'\n",
+    "                                 );"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A typical use case for OGGM will be to use climate model output (here bias-corrected CMIP6 GCMs from [ISIMIP3b](https://www.isimip.org/gettingstarted/isimip3b-bias-adjustment/)). We use some of the files [we store online](https://cluster.klima.uni-bremen.de/~oggm/cmip6/isimip3b/flat/monthly/) here, but you can use whichever you want. From ISIMIP3b, we have 5 GCMs and 3 SSPs on the cluster. You can find more information inside of https://www.isimip.org/gettingstarted/isimip3b-bias-adjustment/\n",
+    "\n",
+    "If you want to bias-correct yourself the projections and want to have a larger variety of GCMs, you can also use the pure CMIP5 or CMIP6 GCMs -> more information is in [this section](#Download-and-process-GCM-data-from-CMIP5-or-CMIP6). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Projection runs "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now run OGGM under various scenarios **and start from the end year of the historical run**:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for ssp in ['ssp126', 'ssp370', 'ssp585']:\n",
+    "    rid = f'_ISIMIP3b_{ensemble}_{ssp}'\n",
+    "    workflow.execute_entity_task(tasks.run_from_climate_data, gdirs, ys=2020, \n",
+    "                                 climate_filename='gcm_data',  # use gcm_data, not climate_historical\n",
+    "                                 climate_input_filesuffix=rid,  # use the chosen scenario\n",
+    "                                 init_model_filesuffix='_historical',  # this is important! Start from 2020 glacier\n",
+    "                                 output_filesuffix=rid,  # recognize the run for later\n",
+    "                                );"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot model output "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "color_dict={'ssp126':'blue', 'ssp370':'orange', 'ssp585':'red'}\n",
+    "for ssp in ['ssp126','ssp370', 'ssp585']:\n",
+    "    rid = f'_ISIMIP3b_{ensemble}_{ssp}'\n",
+    "    ds = utils.compile_run_output(gdirs, input_filesuffix=rid)\n",
+    "    ds.isel(rgi_id=0).volume.plot(ax=ax1, label=ssp, c=color_dict[ssp]);\n",
+    "    ds.isel(rgi_id=1).volume.plot(ax=ax2, label=ssp, c=color_dict[ssp]);\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download and process GCM data from CMIP5 or CMIP6"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead, we can also use the CMIP5 or CMIP5 GCMs directly. However, these need to be bias-corrected first to the applied calibration data (here: GSWP3_W5E5, see [process_gcm_data](https://docs.oggm.org/en/stable/generated/oggm.tasks.process_gcm_data.html#oggm.shop.gcm_climate.process_gcm_data). This bias-correction is automatically done inside of `process_cmip_data` and is very important, as the model is very sensitive to temperature variability.\n",
+    "- CMIP5 has 4 different RCP scenarios and a variety of GCMs, online you can find them [here](https://cluster.klima.uni-bremen.de/~oggm/cmip5-ng). The above mentioned storage contains information about the data, [how to cite them](https://cluster.klima.uni-bremen.de/~oggm/cmip5-ng/ABOUT) and [tabular summaries](https://cluster.klima.uni-bremen.de/~oggm/cmip5-ng/gcm_table.html) of the available GCMs. \n",
+    "- CMIP6 has 4 different SSP scenarios, see [this table](https://cluster.klima.uni-bremen.de/~oggm/cmip6/gcm_table.html) for a summary of available GCMs. There are even some CMIP6 runs that go until [2300](https://cluster.klima.uni-bremen.de/~oggm/cmip6/gcm_table_2300.html).\n",
+    "\n",
+    "> Note, that the CMIP5 and CMIP6 files are much larger than the ISIMIP3b files. This is because we use a simple flattening trick for the ISIMIP3b GCM files as we only save the glacier gridpoints, instead of  each longitude and latitude. **So, only run the following code, if it is ok, to download some gigabytes.** "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download, run the projections and plot the model output by using CMIP5 (note that another GCM is used compared to ISIMIP3b):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bp = 'https://cluster.klima.uni-bremen.de/~oggm/cmip5-ng/pr/pr_mon_CCSM4_{}_r1i1p1_g025.nc'\n",
+    "bt = 'https://cluster.klima.uni-bremen.de/~oggm/cmip5-ng/tas/tas_mon_CCSM4_{}_r1i1p1_g025.nc'\n",
+    "color_dict_rcp={'rcp26':'blue', 'rcp45':'violet', 'rcp85':'red'}\n",
+    "\n",
+    "for rcp in ['rcp26', 'rcp45',  'rcp85']: #'rcp60',\n",
+    "    # Download the files\n",
+    "    ft = utils.file_downloader(bt.format(rcp))\n",
+    "    fp = utils.file_downloader(bp.format(rcp))\n",
+    "    # bias correct them\n",
+    "    workflow.execute_entity_task(gcm_climate.process_cmip_data, gdirs, \n",
+    "                                 filesuffix='_CMIP5_CCSM4_{}'.format(rcp),  # recognize the climate file for later\n",
+    "                                 fpath_temp=ft,  # temperature projections\n",
+    "                                 fpath_precip=fp,  # precip projections\n",
+    "                                 );\n",
+    "for rcp in ['rcp26', 'rcp45',  'rcp85']: #'rcp60',\n",
+    "    rid = '_CMIP5_CCSM4_{}'.format(rcp)\n",
+    "    workflow.execute_entity_task(tasks.run_from_climate_data, gdirs, ys=2020, \n",
+    "                                 climate_filename='gcm_data',  # use gcm_data, not climate_historical\n",
+    "                                 climate_input_filesuffix=rid,  # use the chosen scenario\n",
+    "                                 init_model_filesuffix='_historical',  # this is important! Start from 2020 glacier\n",
+    "                                 output_filesuffix=rid,  # recognize the run for later\n",
+    "                                );\n",
+    "f, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "for rcp in ['rcp26', 'rcp45', 'rcp85']: #'rcp60',\n",
+    "    rid = '_CMIP5_CCSM4_{}'.format(rcp)\n",
+    "    ds = utils.compile_run_output(gdirs, input_filesuffix=rid)\n",
+    "    ds.isel(rgi_id=0).volume.plot(ax=ax1, label=rcp, c=color_dict_rcp[rcp]);\n",
+    "    ds.isel(rgi_id=1).volume.plot(ax=ax2, label=rcp, c=color_dict_rcp[rcp]);\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, the same for CMIP6 but instead of RCPs, now SSPs and again with another GCM:\n",
+    "\n",
+    "(Attention: this will take some time ... )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bp = 'https://cluster.klima.uni-bremen.de/~oggm/cmip6/GCM/CESM2/CESM2_{}_r1i1p1f1_pr.nc'\n",
+    "bt = 'https://cluster.klima.uni-bremen.de/~oggm/cmip6/GCM/CESM2/CESM2_{}_r1i1p1f1_tas.nc'\n",
+    "for ssp in ['ssp126', 'ssp585']:  # Removed 'ssp245', 'ssp370' because the files are large!\n",
+    "    # Download the files\n",
+    "    ft = utils.file_downloader(bt.format(ssp))\n",
+    "    fp = utils.file_downloader(bp.format(ssp))\n",
+    "    # bias correct them\n",
+    "    workflow.execute_entity_task(gcm_climate.process_cmip_data, gdirs, \n",
+    "                                 #year_range=('1979', '2014'),\n",
+    "                                 filesuffix='_CMIP6_CESM2_{}'.format(ssp),  # recognize the climate file for later\n",
+    "                                 fpath_temp=ft,  # temperature projections\n",
+    "                                 fpath_precip=fp,  # precip projections\n",
+    "                                 );\n",
+    "for ssp in ['ssp126', 'ssp585']:\n",
+    "    rid = '_CMIP6_CESM2_{}'.format(ssp)\n",
+    "    workflow.execute_entity_task(tasks.run_from_climate_data, gdirs, ys=2020, \n",
+    "                                 climate_filename='gcm_data',  # use gcm_data, not climate_historical\n",
+    "                                 climate_input_filesuffix=rid,  # use the chosen scenario\n",
+    "                                 init_model_filesuffix='_historical',  # this is important! Start from 2020 glacier\n",
+    "                                 output_filesuffix=rid,  # recognize the run for later\n",
+    "                                );\n",
+    "    \n",
+    "f, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 4))\n",
+    "for ssp in ['ssp126', 'ssp585']:\n",
+    "    rid = '_CMIP6_CESM2_{}'.format(ssp)\n",
+    "    ds = utils.compile_run_output(gdirs, input_filesuffix=rid)\n",
+    "    ds.isel(rgi_id=0).volume.plot(ax=ax1, label=ssp, c=color_dict[ssp]);\n",
+    "    ds.isel(rgi_id=1).volume.plot(ax=ax2, label=ssp, c=color_dict[ssp]);\n",
+    "\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## What's next?\n",
+    "\n",
+    "- see also the tutorial on [Merge, analyse and visualize OGGM GCM runs](merge_gcm_runs_and_visualize.ipynb)\n",
+    "- return to the [OGGM documentation](https://docs.oggm.org)\n",
+    "- back to the [table of contents](welcome.ipynb)"
+   ]
+  }
+ ],
+ "metadata": {
+  "hide_input": false,
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  },
+  "latex_envs": {
+   "LaTeX_envs_menu_present": true,
+   "autoclose": false,
+   "autocomplete": true,
+   "bibliofile": "biblio.bib",
+   "cite_by": "apalike",
+   "current_citInitial": 1,
+   "eqLabelWithNumbers": true,
+   "eqNumInitial": 1,
+   "hotkeys": {
+    "equation": "Ctrl-E",
+    "itemize": "Ctrl-I"
+   },
+   "labels_anchors": false,
+   "latex_user_defs": false,
+   "report_style_numbering": false,
+   "user_envs_cfg": false
+  },
+  "nbTranslate": {
+   "displayLangs": [
+    "*"
+   ],
+   "hotkey": "alt-t",
+   "langInMainMenu": true,
+   "sourceLang": "en",
+   "targetLang": "fr",
+   "useGoogleTranslate": true
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**added a first version of a notebook that explains the OGGM v16 calibration:**
The notebook:
- introduces the default calibration procedure 
- shows how we can calibrate on other data (e.g. from direct glaciological observations from a glacier with in-situ observations) 
- shows the influence of different calibration options and explains the overparameterisation problem

Remaining ToDOs:
- add links to Schuster et al., 2023 preprint
- add other example glacier(s) where in situ-mb != geodetic MB
- add something about the regional dependence of the temperature bias and the way it is used in the OGGM preprocessed levels>=3 ?
- maybe make the notebook a bit easier to read, change the structure? 