### PR TITLE
included informed_threestep, latest changes and DOI for preprint

### DIFF
--- a/notebooks/massbalance_calibration_oggm_v16.ipynb
+++ b/notebooks/massbalance_calibration_oggm_v16.ipynb
@@ -4,20 +4,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# A quick look into the mass-balance calibration procedure"
+    "# A quick look into different mass-balance calibration options"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The default mass-balance (MB) model of OGGM is a very standard [temperature index melt model](https://www.sciencedirect.com/science/article/pii/S0022169403002579). At the beginning, OGGM had a very complicated calibration procedure where the glaciers with in-situ data were calibrated and then a so-called *tstar* got interpolated for glaciers without observations (see the [original publication](https://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html)). This method was very powerful, however, as new observational datasets emerged, we can finally calibrate on a glacier-per-glacier basis. With the new era of geodetic observations, OGGM uses per default the average geodetic observations from Jan 2000--Jan 2020 of [Hugonnet al. 2021](https://www.nature.com/articles/s41586-021-03436-z), that are now available for almost every glacier world-wide. \n",
+    "The default mass-balance (MB) model of OGGM is a very standard [temperature index melt model](https://www.sciencedirect.com/science/article/pii/S0022169403002579). At the beginning, OGGM had a complicated calibration procedure where the glaciers with in-situ data were calibrated and then a so-called *tstar* got interpolated for glaciers without observations (see the [original publication](https://www.the-cryosphere.net/6/1295/2012/tc-6-1295-2012.html)). This method was very powerful, however, as new observational datasets emerged, we can finally calibrate on a glacier-per-glacier basis. With the new era of geodetic observations, OGGM uses per default the average geodetic observations from Jan 2000--Jan 2020 of [Hugonnet al. 2021](https://www.nature.com/articles/s41586-021-03436-z), that are now available for almost every glacier world-wide. \n",
     "\n",
     "In this tutorial, we will:\n",
-    "- [introduce the new default calibration procedure](#Default-calibration-(OGGM->=v1.6)) \n",
-    "- [show how to calibrate on glaciers with in-situ observations](#Other-calibration-options-for-glaciers-with-additional-observations)\n",
+    "- [introduce the new default calibration procedure and variants](#Default-mass-balance-calibration-(OGGM->=v1.6)-and-variants)) \n",
+    "- [show how to calibrate on glaciers with in-situ observations](#Calibrate-on-direct-glaciological-in-situ-MB-observations)\n",
     "- [show how to deal with errors and how to calibrate on other data](#Dealing-with-errors-and-including-your-own-mass-balance-observations)\n",
-    "- [show the influence of different calibration options and explain the overparameterisation problem](#Overparameteristion-or-the-magic-choice-of-the-best-calibration-option:) (more details are e.g. in [Schuster et al., 2023, in review]())"
+    "- [show the influence of different calibration options and explain the overparameterisation problem](#Overparameteristion-or-the-magic-choice-of-the-best-calibration-option:) (more details are e.g. in [Schuster et al., 2023, in review](https://doi.org/10.31223/X5C65S))"
    ]
   },
   {
@@ -42,7 +42,7 @@
     "import oggm\n",
     "from oggm import cfg, utils, workflow, tasks, graphics\n",
     "from oggm.core import massbalance\n",
-    "from oggm.core.massbalance import mb_calibration_from_scalar_mb\n"
+    "from oggm.core.massbalance import mb_calibration_from_scalar_mb, mb_calibration_from_geodetic_mb, mb_calibration_from_wgms_mb"
    ]
   },
   {
@@ -77,13 +77,6 @@
     "gdirs = workflow.init_glacier_directories(['RGI60-11.00787',  'RGI60-11.00897'], from_prepro_level=2,\n",
     "                                          prepro_base_url=base_url)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -136,7 +129,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Default mass-balance calibration (OGGM >=v1.6)"
+    "## Default mass-balance calibration (OGGM >=v1.6) and variants"
    ]
   },
   {
@@ -152,36 +145,66 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Per default the [Hugonnet et al. (2021)](https://www.nature.com/articles/s41586-021-03436-z) average geodetic observation is used over the entire time period Jan 2000 to Jan 2020 to calibrate the melt factor (`melt_f`) for every single glacier. This is done by `mb_calibration_from_scalar_mb` which determines the mass balance parameters from a scalar mass-balance value."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "workflow.execute_entity_task(mb_calibration_from_scalar_mb, gdirs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# if you want to know more about the different options and their meanings\n",
-    "# -> check out the docstring:\n",
-    "# mb_calibration_from_scalar_mb?"
+    "Per default the [Hugonnet et al. (2021)](https://www.nature.com/articles/s41586-021-03436-z) average geodetic observation is used over the entire time period Jan 2000 to Jan 2020 to calibrate the MB model parameter(s) for every single glacier. Note, that, currently, all calibration options available in OGGM only match a scalar average MB estimate of any kind or length.  "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output shows you the calibrated MB model parameters, the used observed reference MB for the calibration (`ref_mb`), the time period and the climate source. Between the two glaciers, only the `melt_f` changed. In the default option, the precipitation factor (`prcp_fac`), depends on the average winter precipitation which is the same for the two neighbouring glaciers (they get their climate from the same climate gridpoint). \n",
+    "**`informed_threestep` with pre-calibrated gridpoint-dependent temperature bias**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the [preprocessed directories](https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/L3-L5_files/2023.1/), per default `informed_threestep=True` and MB model calibration is done by using `mb_calibration_from_geodetic_mb` to determine the MB model parameters. We will reproduce the option from the preprocessed directories first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "workflow.execute_entity_task(mb_calibration_from_geodetic_mb, gdirs, informed_threestep=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# if you want to know more about that function\n",
+    "# check out the docstring:\n",
+    "# mb_calibration_from_geodetic_mb?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output shows you the calibrated MB model parameters, the used observed reference MB for the calibration (`ref_mb`), the time period and the climate source. Between the two glaciers, only the precipitation factor (`prcp_fac`) changed. \n",
     "\n",
-    "The following figure shows the used relationship between winter precipitation and precipitation factor. It was calibrated by adapting `melt_f` and `prcp_fac` to match the average geodetic and winter MB on around 100 glaciers with both informations available. The found relationship of decreasing `prcp_fac` for increasing winter precipitation makes sense, as glaciers with already a large winter precipitation should not be corrected with a large multiplicative `prcp_fac`.  "
+    "---\n",
+    "***A short excursus to explain the calibration procedure applied for the preprocessed directories:*** \n",
+    "- First a pre-calibration is done where the temperature bias (`temp_bias`) is calibrated, while the melt factor (`melt_f`) is fixed at 5 kg m-2 day-1 K-1 and `prcp_fac` is chosen from a relation to the average winter precipitation which is the same for the two neighbouring glaciers (they get their climate from the same climate gridpoint). \n",
+    "\n",
+    "    - Fig.1a shows the used relationship between winter precipitation and `prcp_fac`. It was calibrated by adapting `melt_f` and `prcp_fac` to match the average geodetic and winter MB on around 100 glaciers with both informations available. The found relationship of decreasing `prcp_fac` for increasing winter precipitation makes sense, as glaciers with already a large winter precipitation should not be corrected with a large multiplicative `prcp_fac`.  \n",
+    "- Then, the median temperature bias for every gridpoint that is used to extract climate data for a glacier is estimated . The distribution of it is shown on Fig. 1b. \n",
+    "- Finally, the actual calibration starts with: \n",
+    "    - a `melt_f` of 5 kg m-2 day-1 K-1, \n",
+    "    - a `temp_bias` as estimated from `utils.get_temp_bias_dataframe()['median_temp_bias_w_err_grouped']` (i.e., different for every gridpoint),\n",
+    "    - and a `prcp_fac` that is in the range of $[0.8,1.2]\\times$ `prcp_fac (Fig. 1a)`.\n",
+    "  \n",
+    "- If that worked, the calibration stops. Otherwise, the `melt_f` is changed within a range (and the `prcp_fac`) is at the upper or lower limit of the $[0.8,1.2]$ range. If it still fails, the `temp_bias` is adapated again.\n",
+    "\n",
+    "**This informed step-wise calibration is the option that is used operationally in OGGM>=v1.6 in the preprocessed directories (L>=3) for all glaciers world-wide!**\n",
+    "A detailed explanation of the default calibration will be inside of the OGGM documentation\n",
+    "\n",
+    "---\n"
    ]
   },
   {
@@ -193,45 +216,31 @@
     "w_prcp_array = np.arange(0.5,20,1)\n",
     "# we basically do here the same as in massbalance.decide_winter_precip_factor(gdir)\n",
     "a, b = cfg.PARAMS['winter_prcp_fac_ab']\n",
-    "r0, r1 = cfg.PARAMS['winter_prcp_fac_range']\n",
+    "r0, r1 = cfg.PARAMS['prcp_fac_min'], cfg.PARAMS['prcp_fac_max']\n",
     "prcp_fac = a * np.log(w_prcp_array) + b\n",
     "# don't allow extremely low/high prcp. factors!!!\n",
     "prcp_fac_array = utils.clip_array(prcp_fac, r0, r1)\n",
+    "plt.subplot(121)\n",
     "plt.plot(w_prcp_array, prcp_fac_array)\n",
-    "plt.xlabel(r'winter daily mean precipitation (kg m$^{-2}$ day$^{-1}$)')\n",
-    "plt.ylabel('precipitation factor (prcp_fac)');"
+    "plt.xlabel(r'winter daily mean precipitation' +'\\n'+r'(kg m$^{-2}$ day$^{-1}$)')\n",
+    "plt.ylabel('precipitation factor (prcp_fac)');\n",
+    "plt.title('Fig. 1a')\n",
+    "plt.subplot(122)\n",
+    "temp_b_precalib = utils.get_temp_bias_dataframe()['median_temp_bias_w_err_grouped']\n",
+    "plt.hist(temp_b_precalib);\n",
+    "plt.xlabel('temp_b (°C)')\n",
+    "plt.ylabel('gridpoint frequency')\n",
+    "plt.title('Fig. 1b')\n",
+    "plt.tight_layout()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the default calibration option, we don't apply a temperature bias (`temp_bias`), which could potentially correct the climate to the local scale. However, we will change the three MB model parameters (`melt_f`, `temp_bias` and `prcp_fac`) later and see their influence on the calibration. \n",
+    "For our two neighboring example glaciers, that share the same climate gridpoint, the same pre-calibrated `temp_bias` and the same `melt_f` is used. The `prcp_fac` is slighly different, hence in that example, changing the `prcp_fac` within the narrow range of $[0.8,1.2]$ was sufficient to match the MB model to the observations. \n",
     "\n",
-    "There are also some global MB parameters (`mb_global_params`), which we assume to be the same globally. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "gdirs[-1].read_json('mb_calib')['mb_global_params']"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "These global MB parameter values were found to represent best the in-situ observations during a cross-validation for glaciers with additional observations. Of course, they could also be changed for different glaciers, but this would need even more data to justify the differences! The influence of using a different temperature lapse rate gradient to the default -0.0065 K/km are analysed in [Schuster et al. (2023, in review)]()."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that the two glaciers are in the same climate (from the forcing data) but are very different in size, orientation and geometry. So, the resulting `melt_f` and also the MB values are also different:"
+    "Note that the two glaciers are in the same climate (from the forcing data) but are very different in size, orientation and geometry. So, at least one of the MB model parameters is different (here the `prcp_fac`) and also the observed MB values vary:\n"
    ]
   },
   {
@@ -245,22 +254,48 @@
     "    mean_mb = mbmod.get_specific_mb(fls=gdir.read_pickle('inversion_flowlines'),\n",
     "                                               year=np.arange(2000,2020,1)).mean()\n",
     "    print(gdir.rgi_id, f': average MB 2000-2020 = {mean_mb:.1f} kg m-2, ',\n",
-    "          f\"melt_f: {gdir.read_json('mb_calib')['melt_f']:.1f} kg m-2 day-1 K-1\")"
+    "          f\"prcp_fac: {gdir.read_json('mb_calib')['prcp_fac']:.2f}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Kesselwandferner has a less negative MB than its neighbor, probably because it is smaller in size and spans less altitude."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*To simplify things, we will now focus just on one glacier (Hintereisferner), but you can repeat it of course with other glaciers:*\n",
+    "*Kesselwandferner has a less negative MB than its neighbor, probably because it is smaller in size and spans less altitude.*\n",
     "\n",
+    "*To simplify things, we will now focus just on one glacier (Hintereisferner), but you can repeat it of course with other glaciers:*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will change the three MB model parameters (`melt_f`, `temp_bias` and `prcp_fac`) later and see their influence on the calibration. \n",
+    "\n",
+    "There are also some global MB parameters (`mb_global_params`), which we assume to be the same globally for every glacier. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdir_hef = gdirs[1]\n",
+    "gdir_hef.read_json('mb_calib')['mb_global_params']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These global MB parameter values were found to represent best the in-situ observations during a cross-validation for glaciers with additional observations. Of course, they could also be changed for different glaciers, but this would need even more data to justify the differences! The influence of using a different temperature lapse rate gradient to the default -0.0065 K/km are analysed in [Schuster et al. (2023, in review)](https://doi.org/10.31223/X5C65S)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Let's check if the calibration worked: \n",
     "- We will get first the average modelled MB,"
    ]
@@ -271,7 +306,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdir_hef = gdirs[1]\n",
     "h, w = gdir_hef.get_inversion_flowline_hw()\n",
     "mb_geod = massbalance.MonthlyTIModel(gdir_hef)\n",
     "# Note, if you change cfg.PARAMS['geodetic_mb_period'], you need to change the years here as well!\n",
@@ -295,11 +329,7 @@
    "source": [
     "print('reference MB: ' + str(gdir_hef.read_json('mb_calib')['reference_mb'])+ ' kg m-2')\n",
     "print('reference MB uncertainties: '+ str(gdir_hef.read_json('mb_calib')['reference_mb_err'])+ ' kg m-2')\n",
-    "print('reference MB time period: ' + gdir_hef.read_json('mb_calib')['reference_period'])\n",
-    "# if you use the default calibration data from Hugonnet et al., 2021, \n",
-    "# you can also get the geodetic data from any glacier from here:\n",
-    "# ref_geod_mb = utils.get_geodetic_mb_dataframe().loc[gdir_hef.rgi_id]\n",
-    "# ref_geod_mb_period = ref_geod_mb.loc[ref_geod_mb.period==cfg.PARAMS['geodetic_mb_period']].dmdtda*1000"
+    "print('reference MB time period: ' + gdir_hef.read_json('mb_calib')['reference_period'])\n"
    ]
   },
   {
@@ -323,9 +353,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Perfect! Our MB model reproduces the average observed MB, so the calibrated worked!\n",
-    "\n",
-    "We have calibrated the `melt_f` to match the average geodetic observation and fixed the other parameters. We will now instead fix the `melt_f` and the `prcp_fac`, and use the `temp_bias` as free variable for calibration (by overwriting the default value of `calibrate_param1`)."
+    "Perfect! Our MB model reproduces the average observed MB, so the calibrated worked!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Other calibration variants"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have now used the option that is applied in the preprocessed directories. However, there are many other calibration options. We will show you some, but you could also invent your own for your purposes. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Calibrate `melt_f`, fixed `prcp_fac` and `temp_bìas`**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, let's calibrate the `melt_f` to match the same observations as before (i.e., average geodetic observation) and fix the other parameters. We will now use the more general function `mb_calibration_from_scalar_mb` as it is more flexible. However, it always needs you to give manually the observed MB on which you want to calibrate:"
    ]
   },
   {
@@ -334,15 +390,31 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Let's calibrate on the temp_bias instead\n",
+    "# if you use the default calibration data from Hugonnet et al., 2021, \n",
+    "# we can get the geodetic data from any glacier from here:\n",
+    "ref_mb_df = utils.get_geodetic_mb_dataframe().loc[gdir_hef.rgi_id]\n",
+    "ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == cfg.PARAMS['geodetic_mb_period']]\n",
+    "# dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1\n",
+    "ref_mb = float(ref_mb_df['dmdtda']) * 1000\n",
+    "ref_mb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's calibrate the melt_f (this is the default option in mb_calibration_from_scalar_mb)\n",
     "# overwrite_gdir has to be set to True,\n",
     "# because we want to overwrite the old calibration\n",
     "mb_calibration_from_scalar_mb(gdir_hef,\n",
-    "                              calibrate_param1='temp_bias',\n",
+    "                              ref_mb = ref_mb, \n",
+    "                              ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
     "                              overwrite_gdir=True)\n",
     "\n",
-    "mb_temp_b = massbalance.MonthlyTIModel(gdir_hef)\n",
-    "mbdf['mod_mb_temp_b'] = mb_temp_b.get_specific_mb(h, w, year=mbdf.index)"
+    "mb_melt_f = massbalance.MonthlyTIModel(gdir_hef)\n",
+    "mbdf['mod_mb_melt_f'] = mb_melt_f.get_specific_mb(h, w, year=mbdf.index)"
    ]
   },
   {
@@ -365,14 +437,70 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we used the median `melt_f` (i.e., 5 kg m-2 day-1 K-1) and changed `temp_bias` until the `reference MB` is matched. As the `melt_f` is lower than in the previous calibration option, we need to have a positive `temp_bias` to get to the same average MB."
+    "Only the `melt_f` is used to calibrate the MB model. `prcp_fac` was chosen depending on the average winter precipitation (see Fig. 1a) and `temp_bias` is 0. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**We can do the same with the precipitation factor (`prcp_fac`):** "
+    "**Calibrate `temp_bias`, fixed `prcp_fac` and `melt_f`**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will now instead fix the `melt_f` and the `prcp_fac`, and use the `temp_bias` as free variable for calibration. For that we overwrite the default value of `calibrate_param1`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's calibrate on the temp_bias instead\n",
+    "# overwrite_gdir has to be set to True,\n",
+    "# because we want to overwrite the old calibration\n",
+    "mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "                              ref_mb = ref_mb, \n",
+    "                              ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
+    "                              calibrate_param1='temp_bias',\n",
+    "                              overwrite_gdir=True)\n",
+    "\n",
+    "mb_temp_b = massbalance.MonthlyTIModel(gdir_hef)\n",
+    "mbdf['mod_mb_temp_b'] = mb_temp_b.get_specific_mb(h, w, year=mbdf.index)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gdir_hef.read_json('mb_calib')['temp_bias'], gdir_hef.read_json('mb_calib')['prcp_fac'], gdir_hef.read_json('mb_calib')['melt_f']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we used the median `melt_f` (i.e., 5 kg m-2 day-1 K-1) and the same `prcp_fac` as in the previous option, but changed `temp_bias` until the `ref_mb` is matched. As the `melt_f` is lower than in the previous calibration option, we need to have a positive `temp_bias` to get to the same average MB (i.e., `ref_mb`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Calibrate `prcp_fac`, fixed `temp_bias` and `melt_f`**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also just calibrate on the precipitation factor (`prcp_fac`)."
    ]
   },
   {
@@ -385,12 +513,14 @@
     "# overwrite_gdir has to be set to True,\n",
     "# because we want to overwrite the old calibration\n",
     "mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "                              ref_mb = ref_mb, \n",
+    "                              ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
     "                              calibrate_param1='prcp_fac',\n",
     "                              overwrite_gdir=True)\n",
     "\n",
     "mb_prcp_fac = massbalance.MonthlyTIModel(gdir_hef)\n",
     "mbdf['mod_mb_prcp_fac'] = mb_prcp_fac.get_specific_mb(h, w, year=mbdf.index)\n",
-    "gdir_hef.read_json('mb_calib')"
+    "gdir_hef.read_json('mb_calib')['temp_bias'], gdir_hef.read_json('mb_calib')['prcp_fac'], gdir_hef.read_json('mb_calib')['melt_f']"
    ]
   },
   {
@@ -427,6 +557,8 @@
    "source": [
     "plt.plot(mbdf['in_situ_mb'], label='in-situ observations\\n'+f'average 2000-2020: {mbdf.in_situ_mb.mean():.1f} '+ r'kg m$^{-2}$', color='grey', lw=3)\n",
     "plt.plot(mbdf['mod_mb'],\n",
+    "         label='modelled mass-balance via `informed_threestep`\\n'+f'average 2000-2020: {mbdf.mod_mb.mean():.1f} ' + r'kg m$^{-2}$')\n",
+    "plt.plot(mbdf['mod_mb_melt_f'],\n",
     "         label='modelled mass-balance via calibrating melt_f\\n'+f'average 2000-2020: {mbdf.mod_mb.mean():.1f} ' + r'kg m$^{-2}$')\n",
     "plt.plot(mbdf['mod_mb_temp_b'],\n",
     "         label='modelled mass-balance via calibrating temp_bias\\n'+f'average 2000-2020: {mbdf.mod_mb_temp_b.mean():.1f} ' + r'kg m$^{-2}$')\n",
@@ -444,7 +576,7 @@
    "source": [
     "For this glacier, over the same time period (here 2000-2020), the average MB is quite similar between the geodetic and in-situ observation and could even be explained by the fact that the in-situ observations are in hydrological years (starting in October of the previous year) and the geodetic observations are in calendar years. If you repeat the analysis for other glaciers with in-situ observations over that time period, you might see larger discrepancies. \n",
     "\n",
-    "You can also see, that there are differences in the annual MB between the calibration options and the in-situ observations. We will analyse these differences more systematically later! "
+    "You can also see, that there are differences in the annual MB between the calibration options and the in-situ observations. We will analyse these differences more systematically later! Note, that the `informed_threestep` option is for that glacier very similar to the option where the `temp_bias` is calibrated, however, this is different on other glaciers. "
    ]
   },
   {
@@ -453,7 +585,7 @@
     "tags": []
    },
    "source": [
-    "## Other calibration options for glaciers with additional observations"
+    "## Calibrate on direct glaciological in-situ MB observations"
    ]
   },
   {
@@ -471,7 +603,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "massbalance.mb_calibration_from_wgms_mb(gdir_hef, overwrite_gdir=True)"
+    "mb_calibration_from_wgms_mb(gdir_hef, overwrite_gdir=True)"
    ]
   },
   {
@@ -479,7 +611,7 @@
    "metadata": {},
    "source": [
     "`mb_calibration_from_wgms_mb` is a short-cut function that uses internally `mb_calibration_from_scalar_mb`,\n",
-    "but uses directly the average annual in-situ MB observations from the WGMS. You can get them like that:"
+    "but applies directly the average annual in-situ MB observations from the WGMS. Per default, the `melt_f` is calibrated, and `prcp_fac` and `temp_bias` are fixed. You can get the observations like that:"
    ]
   },
   {
@@ -493,17 +625,6 @@
     "# check that every year between the beginning and the end has MB observations \n",
     "assert len(mbdf_in_situ.index) == (mbdf_in_situ.index[-1] - mbdf_in_situ.index[0] + 1)\n",
     "ref_mb = mbdf_in_situ.ref_mb.mean()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "### There exist a short-cut function is to use \n",
-    "### it does the same thing as above in one line\n",
-    "### (i.e. it calibrates directly on the average in-situ observations"
    ]
   },
   {
@@ -600,7 +721,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's calibrate that glacier (with the default average geodetic observation):"
+    "Let's calibrate that glacier by only changing the `melt_f`, default in `mb_calibration_from_scalar_mb`:"
    ]
   },
   {
@@ -609,10 +730,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mb_calibration_from_scalar_mb(gdir_2)\n",
+    "# first need to get the MB observations again\n",
+    "ref_mb_df = utils.get_geodetic_mb_dataframe().loc[gdir_2.rgi_id]\n",
+    "ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == cfg.PARAMS['geodetic_mb_period']]\n",
+    "# dmdtda: in meters water-equivalent per year -> we convert to kg m-2 yr-1\n",
+    "ref_mb = float(ref_mb_df['dmdtda']) * 1000\n",
+    "ref_mb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mb_calibration_from_scalar_mb(gdir_2, ref_mb=ref_mb, ref_period = cfg.PARAMS['geodetic_mb_period'])\n",
     "# you could also calibrate on the WGMS data instead\n",
     "# as this glacier has in-situ MB observations\n",
-    "# massbalance.mb_calibration_from_wgms_mb(gdir_2, overwrite_gdir=True)"
+    "# mb_calibration_from_wgms_mb(gdir_2, overwrite_gdir=True)"
    ]
   },
   {
@@ -644,9 +779,9 @@
     "If we believe that our observations are true, maybe the climate or the processes represented by the MB model are erroneous. \n",
     "\n",
     "What can we do to still match the `ref_mb`? We can either change the `melt_f` ranges by setting other values to the parameters above or we can allow that another MB model parameter is changed (i.e., `calibrate_param2`). This is basically very similar to the three-step-calibration \n",
-    "first introduced in [Huss & Hock 2015](https://doi.org/10.3389/feart.2015.00054), but you can choose your parameter ranges and parameter order yourself. \n",
+    "first introduced in [Huss & Hock 2015](https://doi.org/10.3389/feart.2015.00054) or in the new `informed_threestep` option for the preprocessed directories in OGGM>=v1.6, but here you can choose your parameter ranges and parameter order yourself. \n",
     "\n",
-    "**To reduce these MB model calibration errors, we will first change the `melt_f`, fix it at the lower or upper limit, and then change the `temp_bias`. This step-wise calibration is also the option that is used operationally in OGGM>=v1.6 in the preprocessed levels >=3 for all glaciers world-wide!**"
+    "To reduce these MB model calibration errors, you can first change the `melt_f`, fix it at the lower or upper limit, and then change the `temp_bias`."
    ]
   },
   {
@@ -656,7 +791,8 @@
    "outputs": [],
    "source": [
     "# Allowing another parameter to change is done by defining calibrate_param2\n",
-    "mb_calibration_from_scalar_mb(gdir_2, calibrate_param2='temp_bias')"
+    "mb_calibration_from_scalar_mb(gdir_2, ref_mb=ref_mb, ref_period = cfg.PARAMS['geodetic_mb_period'], \n",
+    "                              calibrate_param2='temp_bias')"
    ]
   },
   {
@@ -689,7 +825,7 @@
     "ref_period = '2000-01-01_2010-01-01'\n",
     "ref_mb = 2000 # Let's use an unrealistically positive  mass-balance\n",
     "mb_calibration_from_scalar_mb(gdir_hef, ref_mb=ref_mb,\n",
-    "                                ref_period=ref_period, overwrite_gdir=True, write_to_gdir=True,\n",
+    "                                ref_period=ref_period, overwrite_gdir=True, \n",
     "                               calibrate_param2='prcp_fac');\n"
    ]
   },
@@ -749,7 +885,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ref_mb = 3500 # if you replace it with 4000, no combination of parameters can be found for that glacier\n",
+    "ref_mb = 6000 # if you replace it with 8000, no combination of parameters can be found for that glacier\n",
     "mb_calibration_from_scalar_mb(gdir_hef,ref_mb=ref_mb,\n",
     "                              ref_period=ref_period,\n",
     "                              calibrate_param1='prcp_fac',\n",
@@ -808,11 +944,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# let's go back to the Hintereisferner glacier and get again the MB observations:\n",
+    "ref_mb_df = utils.get_geodetic_mb_dataframe().loc[gdir_hef.rgi_id]\n",
+    "ref_mb_df = ref_mb_df.loc[ref_mb_df['period'] == cfg.PARAMS['geodetic_mb_period']]\n",
+    "ref_mb = float(ref_mb_df['dmdtda']) * 1000"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# calibrate the melt_f and annual MB \n",
     "pd_prcp_fac_sens = pd.DataFrame(index=np.arange(0.1,5.0,0.3))\n",
     "spec_mb_prcp_fac_sens_dict = {}\n",
     "for prcp_fac in pd_prcp_fac_sens.index:\n",
-    "    calib_param = mb_calibration_from_scalar_mb(gdir_hef,\n",
+    "    calib_param = mb_calibration_from_scalar_mb(gdir_hef, ref_mb=ref_mb, ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
     "                                                prcp_fac=prcp_fac, overwrite_gdir=True)\n",
     "    pd_prcp_fac_sens.loc[prcp_fac, 'melt_f'] = calib_param['melt_f']\n",
     "    mb_prcp_fac_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
@@ -893,7 +1041,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For the Hintereisferner glacier, the best MB model combination to match the interannual MB variability would be for a `prcp_fac` between 1.6 and 1.9 and a `melt_f` between 6 and 6.5 (more in [Schuster et al., 2023, in review]())."
+    "For the Hintereisferner glacier, the best MB model combination to match the interannual MB variability would be for a `prcp_fac` between 1.6 and 1.9 and a `melt_f` between 6 and 6.5 (more in [Schuster et al., 2023, in review](https://doi.org/10.31223/X5C65S))."
    ]
   },
   {
@@ -907,7 +1055,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**We can also fix the `prcp_fac` and change the `temp_b` and `melt_f` instead:**"
+    "**We can also fix the `prcp_fac`, and change the `temp_bias` and `melt_f` instead:**"
    ]
   },
   {
@@ -924,7 +1072,8 @@
     "    # change the prcp_fac , but here we will just look\n",
     "    # at those combinations where calibration works with a fixed prcp_fac. \n",
     "    try:\n",
-    "        calib_param = mb_calibration_from_scalar_mb(gdir_hef, temp_bias=temp_bias, overwrite_gdir=True)\n",
+    "        calib_param = mb_calibration_from_scalar_mb(gdir_hef, ref_mb=ref_mb, ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
+    "                                                    temp_bias=temp_bias, overwrite_gdir=True)\n",
     "        melt_f_dict_tb[temp_bias] = calib_param['melt_f']\n",
     "        mb_temp_b_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
     "        # ok, we actually matched the new ref_mb\n",
@@ -943,49 +1092,46 @@
     "norm = matplotlib.colors.Normalize(vmin=-5, vmax=5.01)\n",
     "colors_temp_bias = plt.get_cmap('coolwarm')\n",
     "\n",
-    "plt.figure()\n",
+    "fig, axs = plt.subplots(1,2,figsize=(14,6))\n",
     "for j,temp_bias in enumerate(melt_f_dict_tb.keys()):\n",
-    "    plt.plot(temp_bias, melt_f_dict_tb[temp_bias], 'o',\n",
+    "    axs[0].plot(temp_bias, melt_f_dict_tb[temp_bias], 'o',\n",
     "             color=colors_temp_bias(norm(temp_bias))) \n",
-    "plt.ylabel(r'melt_f (kg m$^{-2}$ day$^{-1}$ K$^{-1}$)')\n",
-    "plt.xlabel('temp_bias (°C)');"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A lower `melt_f` is needed if a positive `temp_bias` is applied!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.figure()\n",
+    "axs[0].set_ylabel(r'melt_f (kg m$^{-2}$ day$^{-1}$ K$^{-1}$)')\n",
+    "axs[0].set_xlabel('temp_bias (°C)');\n",
+    "\n",
+    "\n",
     "for temp_bias in melt_f_dict_tb.keys():\n",
-    "    plt.plot(np.arange(2000,2020,1),\n",
+    "    axs[1].plot(np.arange(2000,2020,1),\n",
     "             spec_mb_temp_b_sens_dict[temp_bias], '-', \n",
     "             color=colors_temp_bias(norm(temp_bias)),\n",
     "             label=temp_bias)\n",
-    "plt.plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
+    "axs[1].plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
     "        label='observed in-situ')\n",
-    "plt.ylabel(r'Annual mass-balance (kg m$^{-2}$)')\n",
-    "plt.xlabel('Year')\n",
-    "plt.legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
-    "plt.xticks(np.arange(2000,2020,2));\n",
-    "plt.title(gdir_hef.rgi_id);"
+    "axs[1].set_ylabel(r'Annual mass-balance (kg m$^{-2}$)')\n",
+    "axs[1].set_xlabel('Year')\n",
+    "axs[1].legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
+    "axs[1].set_xticks(np.arange(2000,2020,2));\n",
+    "axs[1].set_title(gdir_hef.rgi_id);\n",
+    "plt.tight_layout()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And the interannual MB variability gets smaller when large positive `temp_bias` are applied. The parameter combination choice or calibration option also influences the modelled seasonal MB or elevation-dependent MB over the calibration period. Additionally, volume and runoff are influenced by the model parameter choice. If you are further interested in that you can have a look into [Schuster et al (2023, in review)](), which analyses the \"Glacier projections sensitivity to temperature-index model choices and calibration strategies\". \n",
-    "\n",
-    "Using prior knowledge on the MB model parameters by a Bayesian calibration scheme is a good option to constrain the parameter ranges. Like that you can also directly include the MB observation uncertainties and quantify the parameter uncertainties. You can read about that in [Rounce et al., 2020](https://doi.org/10.1017/jog.2019.91)!"
+    "A lower `melt_f` is needed if a positive `temp_bias` is applied... and with that the interannual MB variability gets smaller. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Or we change `prcp_fac` and `temp_bias`, and fix the `melt_f`**:"
    ]
   },
   {
@@ -993,7 +1139,74 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "pf_temp_b_dict_tb = {}\n",
+    "spec_mb_pf_temp_b_sens_dict = {}\n",
+    "\n",
+    "for temp_bias in np.arange(-5,5.0,0.5):\n",
+    "    # for too negative temp_bias, no prcp_fac is found that matches the observations. We would need to \n",
+    "    # change the melt_f , but here we will just look\n",
+    "    # at those combinations where calibration works with a fixed melt_f. \n",
+    "    try:\n",
+    "        calib_param = mb_calibration_from_scalar_mb(gdir_hef, calibrate_param1='prcp_fac',\n",
+    "                                                    ref_mb=ref_mb, ref_period=cfg.PARAMS['geodetic_mb_period'],\n",
+    "                                                    temp_bias=temp_bias, overwrite_gdir=True)\n",
+    "        pf_temp_b_dict_tb[temp_bias] = calib_param['prcp_fac']\n",
+    "        mb_pf_temp_b_sens = massbalance.MonthlyTIModel(gdir_hef)\n",
+    "        # ok, we actually matched the new ref_mb\n",
+    "        spec_mb_pf_temp_b_sens_dict[temp_bias] = mb_pf_temp_b_sens.get_specific_mb(h, w, year=np.arange(2000,2020,1))\n",
+    "    except RuntimeError: #, 'RGI60-11.00897: ref mb not matched. Try to set calibrate_param2'\n",
+    "        pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# let's get another centered colormap at temp_bias=0\n",
+    "norm = matplotlib.colors.Normalize(vmin=-5, vmax=5.01)\n",
+    "colors_temp_bias = plt.get_cmap('Spectral_r')\n",
+    "\n",
+    "fig, axs = plt.subplots(1,2,figsize=(14,6))\n",
+    "for j,temp_bias in enumerate(pf_temp_b_dict_tb.keys()):\n",
+    "    axs[0].plot(temp_bias, pf_temp_b_dict_tb[temp_bias], 'o',\n",
+    "             color=colors_temp_bias(norm(temp_bias))) \n",
+    "axs[0].set_ylabel(r'prcp_fac')\n",
+    "axs[0].set_xlabel('temp_bias (°C)');\n",
+    "\n",
+    "\n",
+    "for temp_bias in pf_temp_b_dict_tb.keys():\n",
+    "    axs[1].plot(np.arange(2000,2020,1),\n",
+    "             spec_mb_pf_temp_b_sens_dict[temp_bias], '-', \n",
+    "             color=colors_temp_bias(norm(temp_bias)),\n",
+    "             label=temp_bias)\n",
+    "axs[1].plot(mbdf_in_situ.loc[2000:2019].index, mbdf_in_situ.loc[2000:2019]['ANNUAL_BALANCE'], color='grey', lw=3, \n",
+    "        label='observed in-situ')\n",
+    "axs[1].set_ylabel(r'Annual mass-balance (kg m$^{-2}$)')\n",
+    "axs[1].set_xlabel('Year')\n",
+    "axs[1].legend(title='temp_bias:', bbox_to_anchor=(1,1))\n",
+    "axs[1].set_xticks(np.arange(2000,2020,2));\n",
+    "axs[1].set_title(gdir_hef.rgi_id);\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A larger `temp_bias` needs a larger `prcp_fac` ... and with that the interannual MB variability gets larger."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The parameter combination choice or calibration option also influences the modelled seasonal MB or elevation-dependent MB over the calibration period. Additionally, volume and runoff are influenced by the model parameter choice. If you are further interested in that, you can have a look into [Schuster et al (2023, in review)](https://doi.org/10.31223/X5C65S), which analyses the \"Glacier projections sensitivity to temperature-index model choices and calibration strategies\". \n",
+    "\n",
+    "Using prior knowledge on the MB model parameters by a Bayesian calibration scheme is a good option to constrain the parameter ranges. Like that you can also directly include the MB observation uncertainties and quantify the parameter uncertainties. You can read about that in [Rounce et al., 2020](https://doi.org/10.1017/jog.2019.91)! We are working on including a Bayesian calibration framework into OGGM by using the `informed_threestep` calibration procedure as prior estimates."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1010,10 +1223,11 @@
     "- We can use different observational data for calibration: \n",
     "    - calibrating to geodetic observations using different time periods, to in-situ direct glaciological observations from the WGMS (if available) or to other custom MB data.  \n",
     "- There exist different ways of calibrating to the average observational data:\n",
-    "    - default is to calibrate the `melt_f`, and having the `prcp_fac` and `temp_bias` fixed. If the calibration does not work, the `temp_bias` is varied aswell. This is the option that is used operationally in OGGM in the preprocessed levels >=3 for all glaciers world-wide.\n",
+    "    - You can use the same option (`informed_threestep`) as done operationally for the [preprocessed directories (L>=3)](https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/L3-L5_files/2023.1/elev_bands/W5E5/) on all glaciers world-wide \n",
+    "    - you can calibrate the `melt_f`, and have the `prcp_fac` and `temp_bias` fixed. If the calibration does not work, the `temp_bias` can be varied aswell. \n",
     "    - you can also calibrate instead on `prcp_fac` or `temp_bias` and fix the other parameters.\n",
-    "    - However, we showed that the parameter combination choice has an influence on other estimates than the average MB. The model parameter calibration choice can also impact future volume and runoff projections (see [Schuster et al., 2023, in review]()). \n",
-    "- As user of OGGM, you will most likely just use the default calibration option. However, it is good to be aware of the overparameterisation problem. In addition, if you want to include uncertainties of the MB model calibration, you could include additional experiments that use another calibration option. With more available observational data or improved climate data, you might also be able to use better ways to calibrate the MB model parameters. \n"
+    "- However, we showed that the parameter combination choice has an influence on other estimates than the average MB (which then influences also future projections). \n",
+    "- As user of OGGM, you might just use the calibrated MB model parameters from the preprocessed directories. Nevertheless, it is good to be aware of the overparameterisation problem. In addition, if you want to include uncertainties of the MB model calibration, you could include additional experiments that use another calibration option and create your own preprocessed directories with these options. With more available observational data or improved climate data, you might also be able to use better ways to calibrate the MB model parameters. \n"
    ]
   },
   {

--- a/notebooks/run_with_gcm_oggm_v16.ipynb
+++ b/notebooks/run_with_gcm_oggm_v16.ipynb
@@ -73,7 +73,7 @@
     "# in OGGM v1.6 you have to explicitly indicate the url from where you want to start from\n",
     "# we will use here the elevation band flowlines which are much simpler than the centerlines\n",
     "base_url = ('https://cluster.klima.uni-bremen.de/~oggm/gdirs/oggm_v1.6/'\n",
-    "            'exps/L3-L5_files/W5E5_melt_calib')\n",
+    "            'L3-L5_files/2023.1/elev_bands/W5E5/')\n",
     "gdirs = workflow.init_glacier_directories(rgi_ids, from_prepro_level=5,\n",
     "                                         prepro_base_url=base_url)"
    ]
@@ -330,7 +330,7 @@
    "source": [
     "Now, the same for CMIP6 but instead of RCPs, now SSPs and again with another GCM:\n",
     "\n",
-    "(Attention: this will take some time ... )"
+    "(Attention: this will take some time when you run it first, as it needs to download the files first ... )"
    ]
   },
   {


### PR DESCRIPTION
- both notebooks are now compatible with the newest OGGM_v16 changes:

I specifically also included the calibration procedure that is applied for the preprocessed directories in the MB calibration notebook. So, I adapted the notebook to introduce `mb_calibration_from_geodetic_mb`,  `mb_calibration_from_scalar_mb` and  `mb_calibration_from_wgms_mb`. 