### PR TITLE
adapt binder environment

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -19,7 +19,9 @@ dependencies:
   - dask
   - bottleneck
   - pyproj
-  - cartopy
+  - geos
+  - shapely
+  - pyshp
   - geopandas
   - rioxarray
   - seaborn
@@ -36,3 +38,4 @@ dependencies:
     - progressbar2
     - git+https://github.com/OGGM/oggm-edu
     - oggm
+    - cartopy


### PR DESCRIPTION
Here I adapted the installation of `cartopy` in binder (following https://scitools.org.uk/cartopy/docs/latest/installing.html) as there was an error during the binder build.

This PR could be one solution for the issue https://github.com/OGGM/tutorials/issues/89, when using https://mybinder.org/ to create the link for the tutorials. But there may be a better way to deal with this issue.

However, the current binder link on https://docs.oggm.org/en/latest/cloud.html looks different and is longer than the one you can create on https://mybinder.org/. I do not know why.