### PR TITLE
chore: rotate logo for default (2026-07-29)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@
 title: OGGM tutorials  # The title of the book. Will be placed in the left navbar.
 author: OGGM e.V. and OGGM Contributors  # The author of the book
 copyright: "2014-2025"  # Copyright year to be placed in the footer
-logo: img/celebrations/oggm_logo_pride.png  # A path to the book logo
+logo: img/logo.png  # A path to the book logo
 repository:
   url: https://github.com/OGGM/tutorials
   path_to_book: .


### PR DESCRIPTION
Automated logo rotation update for **OGGM/tutorials** (stable branch).

- Date: 
- Event: default
- Window: none
- New logo: img/logo.png
- Event URL: 
- Previous logo: img/celebrations/oggm_logo_pride.png

This PR was generated by `OGGM/oggm.github.io/.github/workflows/logo-rotation-pr.yml`.